### PR TITLE
Investigate Y slider zoom control improvements #348 

### DIFF
--- a/web-client/src/utils/plotUtils.ts
+++ b/web-client/src/utils/plotUtils.ts
@@ -651,6 +651,7 @@ export async function getScatterOptions(req_id:number): Promise<any> {
                         width: 20,
                         start: atlChartFilterStore.yZoomStart, // Start zoom level
                         end: atlChartFilterStore.yZoomEnd, // End zoom level
+                        showDataShadow: false,
                     },
                     {
                         type: 'inside', // This allows zooming inside the chart using mouse wheel or touch gestures


### PR DESCRIPTION
Investigate Y slider zoom control improvements #348 

Confirmed no support in echarts to generate a datashadow. 
The default is a ramp, we will disable