### PR TITLE
Use `assets` endpoint to get list of raster datasets that can be samp…

### DIFF
--- a/web-client/src/components/SrRasterParams.vue
+++ b/web-client/src/components/SrRasterParams.vue
@@ -138,8 +138,14 @@
     import SrCatalogFileUpload from './SrCatalogFileUpload.vue';
     import SrLabelInfoIconButton from './SrLabelInfoIconButton.vue';
     import Sr32BitFlag from './Sr32BitFlag.vue';
+    import { onMounted } from 'vue';
 
     const rasterParamsStore = useRasterParamsStore();
+
+    onMounted(() => {
+        rasterParamsStore.setAssetOptions();
+    });
+
     const addRasterParams = () => {
 
         if(rasterParamsStore.key === '' || rasterParamsStore.asset === '') {

--- a/web-client/src/stores/rasterParamsStore.ts
+++ b/web-client/src/stores/rasterParamsStore.ts
@@ -165,5 +165,20 @@ export const useRasterParamsStore = defineStore('rasterParams', {
                 bands: Array.isArray(entry.bands) ? entry.bands : [],
             }));
         },
+        async setAssetOptions() {
+            try {
+                const response = await fetch('https://sliderule.slideruleearth.io/source/assets');
+                if (!response.ok) {
+                    throw new Error(`Failed to fetch assets: ${response.statusText}`);
+                }
+
+                const result = await response.json();
+                const rasters: string[] = result.rasters || [];
+
+                this.assetOptions = rasters.map(r => ({ name: r, value: r }));
+            } catch (error) {
+                console.error('Error loading asset options:', error);
+            }
+        },
     }
 });


### PR DESCRIPTION
…led #563