### PR TITLE
Pin toolchain and add Make targets to prevent build drift

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,27 @@
+# Normalize text line endings across platforms
+* text=auto eol=lf
+
+# Explicit binary types — never apply EOL/text filters
+*.png     binary
+*.jpg     binary
+*.jpeg    binary
+*.gif     binary
+*.ico     binary
+*.webp    binary
+*.svg     binary
+*.pdf     binary
+*.woff    binary
+*.woff2   binary
+*.ttf     binary
+*.otf     binary
+*.eot     binary
+*.mp4     binary
+*.mp3     binary
+*.zip     binary
+*.gz      binary
+*.tgz     binary
+*.parquet binary
+*.wasm    binary
+
+# Lockfile — treat as text but mark as generated so GitHub collapses it in diffs
+package-lock.json linguist-generated=true

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -18,22 +18,25 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: '.nvmrc'
           cache: npm
-          cache-dependency-path: web-client/package-lock.json
+          cache-dependency-path: |
+            package-lock.json
+            web-client/package-lock.json
+
+      - name: Enable Corepack (honors packageManager field)
+        run: corepack enable
 
       - name: Create .env.ci at repo root
-        working-directory: web-client
         run: |
           {
             echo "BASE_URL=http://localhost:5173"
             echo "VITE_APP_ENV=ci"
             # echo "VITE_API_BASE=${{ secrets.VITE_API_BASE }}"
-          } > ../.env.ci
+          } > .env.ci
 
-      - name: Install deps
-        working-directory: web-client
-        run: npm ci
+      - name: Install deps + verify lockfile drift (root and web-client)
+        run: make verify-lockfiles
 
       - name: Install Playwright browsers
         working-directory: web-client
@@ -50,8 +53,7 @@ jobs:
           node -p "require.resolve('@playwright/test/package.json')"
 
       - name: Run Playwright tests
-        working-directory: web-client
-        run: npx playwright test
+        run: make test-e2e
 
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,131 @@
+# SlideRule Web Client — Claude Code guide
+
+Guidance for Claude Code sessions working in this repo. Read this before making
+changes.
+
+## Repo layout
+
+This is a **two-level npm project**:
+
+```
+sliderule-web-client/                  ← git root, outer wrapper
+├── package.json                       ← husky, Playwright orchestration
+├── package-lock.json
+├── Makefile                           ← canonical interface (use this!)
+├── web-client/                        ← the Vue 3 app
+│   ├── package.json                   ← runtime deps, Vite, TypeScript, ESLint
+│   ├── package-lock.json
+│   ├── src/                           ← all app source
+│   ├── tests/                         ← Vitest unit + Playwright E2E
+│   └── playwright.config.mts
+├── sliderule-mcp-server/              ← Python MCP server (separate project)
+├── terraform/                         ← infra (CloudFront + S3)
+├── keycloak/                          ← local OAuth dev harness
+├── lambda/                            ← AWS Lambda code
+└── docs/
+```
+
+Both `package.json`s require installs. Both are guarded with `engines` +
+`packageManager` + `.npmrc` (`engine-strict=true`).
+
+## Use the Makefile, not raw commands
+
+The Makefile is the single source of truth. CI calls it; local dev should too.
+Prefer `make <target>` over `npm run ...` / `vite ...` / `npx ...` directly.
+
+Key targets:
+
+| Task | Command | Notes |
+|---|---|---|
+| Install npm deps | `make install-deps` | Runs `npm ci` at root **and** `web-client/` |
+| Reinstall npm deps (clean) | `make reinstall-deps` | `clean-all` + `install-deps` |
+| Full rebuild from scratch | `make rebuild-all` | `reinstall-deps` + `build` |
+| Regenerate lockfiles | `make regen-lockfiles` | Destructive, rarely needed |
+| Verify env | `make doctor` | Shows Node/npm vs pinned versions |
+| Verify lockfiles | `make verify-lockfiles` | Mirrors the CI drift check |
+| Dev server | `make run` | NOT `npm run dev` |
+| Production build | `make build` | NOT `vite build` — Makefile injects VITE_APP_VERSION etc. |
+| Preview build | `make preview` | |
+| Typecheck | `make typecheck` | |
+| Lint / fix | `make lint` / `make lint-fix` | |
+| Unit tests | `make test-unit` | Vitest |
+| E2E tests | `make test-e2e` | Playwright (runs from web-client/) |
+| All CI checks | `make ci-check` | |
+| Full list | `make help` | |
+
+## Toolchain (strict)
+
+- **Node** — version pinned in [`.nvmrc`](.nvmrc). Enforced via `engines` +
+  `engine-strict=true`. Use fnm or nvm; Homebrew Node works but doesn't respect
+  Corepack.
+- **npm** — version pinned in `packageManager` field (both package.json files).
+  Corepack fetches the exact version on contributors' machines. Requires
+  `corepack enable && corepack enable npm`.
+- **Never** run `npm install` without intent. `make install-deps` (which wraps
+  `npm ci`) is the default. `npm install` re-resolves and rewrites lockfiles —
+  CI will catch this via the drift check.
+
+## Line endings and binaries
+
+[`.gitattributes`](.gitattributes) normalizes line endings to LF and marks
+images/fonts/wasm/parquet as binary. When adding a new binary asset type, add
+an explicit rule there.
+
+## Domains
+
+**`sliderule.slideruleearth.io` is hardcoded intentionally** as the permanent
+public API server. Do not parameterize or "generalize" it without discussing
+the architectural implications first.
+
+## MCP integration
+
+A Model Context Protocol bridge exposes web-client state/actions to LLMs:
+
+- **Browser side** (authoritative): [`web-client/src/services/mcpClient.ts`](web-client/src/services/mcpClient.ts),
+  [`mcpHandler.ts`](web-client/src/services/mcpHandler.ts),
+  [`toolExecutor.ts`](web-client/src/services/toolExecutor.ts),
+  [`toolDefinitions.ts`](web-client/src/services/toolDefinitions.ts)
+- **Pinia store**: [`web-client/src/stores/mcpStore.ts`](web-client/src/stores/mcpStore.ts)
+- **UI**: [`web-client/src/components/SrMcpActivityIndicator.vue`](web-client/src/components/SrMcpActivityIndicator.vue)
+- **Server side**: [`sliderule-mcp-server/`](sliderule-mcp-server/) (Python;
+  stdio for Claude Desktop, HTTP/SSE for Claude.ai/ChatGPT via ECS relay)
+
+`toolDefinitions.ts` is the authoritative source of tool schemas. Server is a
+transparent bridge — tool logic lives in the browser (Pinia stores, DuckDB,
+OpenLayers).
+
+## Build / deploy
+
+- `make build` produces `web-client/dist/`
+- Deploy targets like `make deploy-client-to-slideruleearth` handle S3 upload
+  and CloudFront invalidation via Terraform (`terraform/`)
+- `make keycloak-up`/`keycloak-down` spin up a local OAuth server for auth dev
+
+## Lint config quirk
+
+ESLint flat config is explicitly **disabled** in the lint scripts:
+`ESLINT_USE_FLAT_CONFIG=false`. Do not "fix" this by migrating to flat config
+without coordinating — the legacy config is intentional here.
+
+## Testing
+
+- **Unit**: Vitest, `make test-unit`, sources in `web-client/tests/`
+- **E2E**: Playwright, `make test-e2e`, config in
+  [`web-client/playwright.config.mts`](web-client/playwright.config.mts). The
+  CI workflow runs E2E against the production build.
+- Pre-commit hook runs `lint-staged` + typecheck + unit tests. Manual
+  equivalent: `make pre-commit-check`.
+
+## Reproducibility guardrails (what's enforced)
+
+1. `engines` + `engine-strict=true` in both `.npmrc` files → wrong Node/npm
+   versions fail install outright
+2. `packageManager: npm@<pinned>` in both `package.json` files + Corepack →
+   exact npm version fetched and used
+3. `make verify-lockfiles` (local + CI) → `npm ci` must not rewrite
+   `package.json` or `package-lock.json` in either location
+4. [`.gitattributes`](.gitattributes) → no line-ending corruption of binaries
+   across platforms
+
+If you see a large, unexplained lockfile diff or a package version change that
+nobody intended, treat it as a bug — don't rubber-stamp the PR.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,114 @@
+# Contributing
+
+## Setting up your environment
+
+This repo pins the Node and npm toolchain so every developer (and CI) builds
+against identical versions. Please do not skip these steps — drift here is the
+number-one cause of "works on my machine" bugs.
+
+1. **Install a Node version manager that reads `.nvmrc`.** [fnm](https://github.com/Schniz/fnm)
+   is recommended (faster than nvm, auto-switches on `cd`). Homebrew Node works
+   too but will not respect Corepack's `packageManager` enforcement.
+   ```bash
+   brew install fnm
+   # Add to ~/.zshrc:
+   #   eval "$(fnm env --use-on-cd --shell zsh)"
+   ```
+
+2. **Install the pinned Node version.** The version is in [`.nvmrc`](.nvmrc).
+   ```bash
+   fnm install   # installs the pinned version
+   fnm use       # activates it in the current shell
+   ```
+
+3. **Enable Corepack.** This lets Node fetch the exact npm version specified by
+   the `packageManager` field in [`package.json`](package.json):
+   ```bash
+   corepack enable
+   corepack enable npm   # Corepack doesn't shim npm by default — this opts in
+   ```
+
+4. **Install npm dependencies via the Makefile**:
+   ```bash
+   make install-deps
+   ```
+
+   This runs `npm ci` at both the **repo root** and inside **`web-client/`**.
+   Both installs are required — the root owns husky git hooks and Playwright
+   orchestration; `web-client/` owns the actual Vue app.
+
+## Why two `package.json`s?
+
+- **Root `package.json`** — git hooks (husky), Playwright runner, environment
+  tooling. Must live at the git root because husky installs hooks into `.git/`.
+- **`web-client/package.json`** — the Vue 3 app: runtime dependencies, build
+  tooling (Vite, TypeScript, ESLint), all the things you'd expect.
+
+## Use the Makefile for everything
+
+The Makefile is the canonical interface. Prefer it over raw `npm`/`vite`
+commands so your local workflow matches CI.
+
+| Task | Command |
+|---|---|
+| Fresh-clone install of npm deps | `make install-deps` |
+| Clean + reinstall npm deps (preserves lockfiles) | `make reinstall-deps` |
+| Full rebuild from scratch (wipe + reinstall + build) | `make rebuild-all` |
+| Regenerate lockfiles from scratch (rare) | `make regen-lockfiles` |
+| Verify your Node/npm versions | `make doctor` |
+| Verify lockfiles are in sync (CI guardrail) | `make verify-lockfiles` |
+| Run dev server | `make run` |
+| Production build | `make build` |
+| Preview production build | `make preview` |
+| TypeScript check | `make typecheck` |
+| Lint / lint-fix | `make lint` / `make lint-fix` |
+| Unit tests | `make test-unit` |
+| E2E tests | `make test-e2e` |
+| Run everything CI runs | `make ci-check` |
+| Full help | `make help` |
+
+## The `npm ci` vs `npm install` rule
+
+- **`make install-deps` (wraps `npm ci`)** — installs exactly what is in the
+  lockfiles. Never modifies `package.json` or the lockfiles. **Use this for
+  every fresh clone, every branch switch, and in CI.**
+- **`npm install`** — re-resolves dependencies and may rewrite both
+  `package.json` and `package-lock.json`. **Only use this when you are
+  intentionally adding or upgrading a dependency**, and commit both files
+  together in the same commit.
+
+If a PR diff shows large, unexpected changes to either `package-lock.json`,
+something is wrong — usually a wrong Node/npm version, or `npm install` was run
+by accident. Revert the lockfile changes, run `make install-deps`, and try again.
+
+## Adding or upgrading a dependency
+
+Decide which `package.json` the dep belongs in (root vs `web-client/`), then:
+
+```bash
+cd web-client                  # or stay at root, depending on target
+npm install <pkg>@<version>    # or: npm install <pkg> for latest compatible
+```
+
+Commit both `package.json` and `package-lock.json` from that directory in the
+same commit.
+
+## CI guardrails
+
+The Playwright workflow calls the same Make targets you use locally:
+
+- **`make verify-lockfiles`** — fails if `npm ci` produces a diff against
+  committed `package.json`/`package-lock.json` in either location.
+- **`engine-strict=true`** in both `.npmrc` files — blocks Node/npm versions
+  below the `engines` range.
+- **`make test-e2e`** — the same Playwright command you can run locally.
+
+If CI fails on lockfile drift, running `make verify-lockfiles` on your branch
+will reproduce the failure.
+
+## Line endings and binary files
+
+Line-ending and binary-file rules live in [`.gitattributes`](.gitattributes).
+If you are adding a new binary asset type (e.g. a new font or image format)
+not already listed, add an explicit `binary` rule there so cross-platform
+checkouts don't corrupt it.

--- a/Makefile
+++ b/Makefile
@@ -16,14 +16,46 @@ VERSION ?= latest
 BANNER_TEXT ?=
 
 
-clean-all: # Clean up the web client dependencies 
-	rm -rf *.zip web-client/dist web-client/node_modules web-client/package-lock.json
+clean-all: ## Remove node_modules and build artifacts (preserves package-lock.json files)
+	rm -rf *.zip web-client/dist web-client/node_modules node_modules
 
-clean: ## Clean only the build artifacts
+clean: ## Remove only the build artifacts (web-client/dist)
 	rm -rf web-client/dist
 
-reinstall: clean-all ## Reinstall the web client dependencies
+regen-lockfiles: ## DESTRUCTIVE: delete and regenerate package-lock.json files via `npm install` (only for intentional dep upgrades)
+	rm -f package-lock.json web-client/package-lock.json
+	npm install
 	cd web-client && npm install
+
+install-deps: ## Install npm dependencies (runs `npm ci` at root AND in web-client/ — use this on a fresh clone)
+	npm ci
+	cd web-client && npm ci
+
+reinstall-deps: clean-all install-deps ## Wipe node_modules then re-run `npm ci` (committed lockfiles are respected)
+
+rebuild-all: reinstall-deps build ## Full refresh: wipe node_modules + dist, reinstall npm deps, and rebuild the web client
+
+verify-lockfiles: ## Run `npm ci` and fail if package.json/package-lock.json drift (local mirror of the CI guardrail)
+	npm ci
+	cd web-client && npm ci
+	git diff --exit-code package.json package-lock.json web-client/package.json web-client/package-lock.json
+
+audit-deps: ## Run `npm audit` at root AND in web-client/ (read-only — reports vulnerabilities, does not modify anything)
+	@echo "=== ROOT ==="
+	-npm audit
+	@echo ""
+	@echo "=== web-client ==="
+	-cd web-client && npm audit
+
+audit-fix-deps: ## Apply `npm audit fix` at root AND in web-client/ (rewrites package-lock.json — review and commit the diff)
+	npm audit fix
+	cd web-client && npm audit fix
+
+doctor: ## Check that your Node/npm versions match .nvmrc and the packageManager pin
+	@echo "Expected Node: $$(cat .nvmrc)"
+	@echo "Actual Node:   $$(node --version)"
+	@echo "Expected npm:  $$(node -p "require('./package.json').packageManager")"
+	@echo "Actual npm:    npm@$$(npm --version)"
 
 src-tag-and-push: ## Tag and push the web client source code to the repository
 	$(ROOT)/VITE_VERSION.sh $(VERSION) && git push --tags; git push
@@ -170,7 +202,7 @@ deploy-client-to-slideruleearth: ## Deploy the web client to the slideruleearth.
 destroy-client-slideruleearth: ## Destroy the web client from the slideruleearth.io cloudfront and remove the S3 bucket
 	make destroy DOMAIN=client.slideruleearth.io S3_BUCKET=slideruleearth-webclient DOMAIN_APEX=slideruleearth.io
 
-.PHONY: check-vars typecheck lint lint-fix lint-staged pre-commit-check test-unit test-unit-watch coverage-unit test-e2e test-all ci-check keycloak-up keycloak-down keycloak-run
+.PHONY: install-deps reinstall-deps rebuild-all regen-lockfiles verify-lockfiles audit-deps audit-fix-deps doctor check-vars typecheck lint lint-fix lint-staged pre-commit-check test-unit test-unit-watch coverage-unit test-e2e test-all ci-check keycloak-up keycloak-down keycloak-run
 # =========================
 # Testing / Quality targets
 # =========================
@@ -217,12 +249,7 @@ test-all: typecheck lint test-unit test-e2e ## Run all checks
 pw-report: ## Open the last Playwright HTML report
 	cd web-client && npm run pw:report
 
-ci-check: ## CI gate: clean install + types + lint + unit + e2e
-	cd web-client && npm ci
-	cd web-client && npm run typecheck
-	cd web-client && npm run lint
-	cd web-client && npm run test:unit
-	cd web-client && npm run test:e2e
+ci-check: verify-lockfiles typecheck lint test-unit test-e2e ## CI gate: lockfile drift + types + lint + unit + e2e
 
 check-vars:
 	@test -n "$(DOMAIN)" || (echo "❌ DOMAIN is not set"; exit 1)

--- a/README.md
+++ b/README.md
@@ -25,30 +25,36 @@ To run this web client locally, follow the instructions below.
 
 ### Prerequisites
 
-- **Node.js** v14 or higher
-- **npm** or **yarn**
+- **Node.js** — exact version pinned in [`.nvmrc`](.nvmrc). Use [fnm](https://github.com/Schniz/fnm) (recommended) or nvm: `fnm install && fnm use`.
+- **npm** — version pinned by the `packageManager` field in [`package.json`](package.json). Enable Corepack once with `corepack enable && corepack enable npm` and it will fetch the right version automatically.
+- See [CONTRIBUTING.md](CONTRIBUTING.md) for full setup and the `make install-deps` vs `npm install` rule.
 
 ### Installation
 
 1. Clone this repository:
    ```bash
-   git clone https://github.com/yourusername/your-web-client-repo.git
-   cd your-web-client-repo
+   git clone https://github.com/SlideRuleEarth/sliderule-web-client.git
+   cd sliderule-web-client
    ```
 
-2. Install dependencies:
+2. Install npm dependencies (installs both the root and `web-client/` packages via `npm ci`):
    ```bash
-   npm install
+   make install-deps
    ```
 
 3. Run the development server:
    ```bash
-   npm run dev
+   make run
    ```
 
 4. Build for production:
    ```bash
-   npm run build
+   make build
+   ```
+
+5. See all available commands:
+   ```bash
+   make help
    ```
 
 ## Open Source Packages

--- a/package.json
+++ b/package.json
@@ -3,6 +3,11 @@
   "version": "1.0.0",
   "description": "---",
   "main": "index.js",
+  "engines": {
+    "node": ">=20.0.0",
+    "npm": ">=10.0.0"
+  },
+  "packageManager": "npm@11.4.2",
   "directories": {
     "doc": "docs"
   },

--- a/web-client/.npmrc
+++ b/web-client/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/web-client/package.json
+++ b/web-client/package.json
@@ -2,6 +2,11 @@
   "name": "web-client",
   "version": "0.0.0",
   "private": true,
+  "engines": {
+    "node": ">=20.0.0",
+    "npm": ">=10.0.0"
+  },
+  "packageManager": "npm@11.4.2",
   "scripts": {
     "test:unit": "vitest --run",
     "test:unit:watch": "vitest",


### PR DESCRIPTION
## Summary
- Pin Node via `.nvmrc` + npm via `packageManager` field (root and `web-client/`), enforced by `engine-strict=true` in `.npmrc`.
- Add Make targets for the reproducibility story: `install-deps`, `reinstall-deps`, `rebuild-all`, `verify-lockfiles`, `audit-deps`, `audit-fix-deps`, `regen-lockfiles`, `doctor`.
- Rewire the Playwright CI workflow through the Makefile so local dev and CI share one source of truth; add a lockfile-drift guard (`make verify-lockfiles`) that fails CI if `npm ci` rewrites `package.json`/`package-lock.json`.
- Add `.gitattributes` for line-ending + binary-file safety across platforms.
- Add `CLAUDE.md` (Claude Code guidance) and `CONTRIBUTING.md` (contributor onboarding + the `make install-deps` vs `npm install` rule).

No lockfile rewrites in this PR — it is pure infrastructure. The root and `web-client/` `package.json` files only gain new fields (`engines`, `packageManager`); no existing dependency versions move.

## Test plan
- [ ] `make doctor` reports matching Node/npm versus `.nvmrc` and `packageManager`
- [ ] `make install-deps` succeeds (both root and `web-client/` install cleanly)
- [ ] `make verify-lockfiles` succeeds (no drift)
- [ ] `make rebuild-all` succeeds end-to-end (wipe + reinstall + full Vite build)
- [ ] CI Playwright workflow runs green on the new `make`-based steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)