### PR TITLE
Add toggle to show/hide historical request polygons (#1062)

### DIFF
--- a/web-client/src/components/SrHistoricalRequestsControl.vue
+++ b/web-client/src/components/SrHistoricalRequestsControl.vue
@@ -1,0 +1,125 @@
+<script setup lang="ts">
+import { ref, onMounted, onUnmounted, computed } from 'vue'
+import { Control } from 'ol/control'
+import { useMapStore } from '@/stores/mapStore'
+import { createLogger } from '@/utils/logger'
+
+const logger = createLogger('SrHistoricalRequestsControl')
+
+const mapStore = useMapStore()
+const controlElement = ref<HTMLElement | null>(null)
+const emit = defineEmits<{
+  (_e: 'historical-requests-control-created', _control: Control): void
+}>()
+
+let customControl: Control | null = null
+
+const isChecked = computed({
+  get: () => mapStore.historicalPolysVisible,
+  set: (value: boolean) => {
+    mapStore.historicalPolysVisible = value
+  }
+})
+
+onMounted(() => {
+  if (controlElement.value) {
+    customControl = new Control({ element: controlElement.value })
+    emit('historical-requests-control-created', customControl)
+  }
+})
+
+onUnmounted(() => {
+  if (customControl) {
+    customControl.setMap(null)
+  }
+})
+
+function handleVisibilityChanged() {
+  logger.debug('handleVisibilityChanged', {
+    historicalPolysVisible: mapStore.historicalPolysVisible
+  })
+  mapStore.setHistoricalPolysVisible(mapStore.historicalPolysVisible)
+}
+</script>
+
+<template>
+  <div ref="controlElement" class="sr-historical-requests-control ol-unselectable ol-control">
+    <div class="checkbox-container" title="Toggle historical request polygons & reqIds">
+      <input
+        id="historical-requests-toggle"
+        v-model="isChecked"
+        type="checkbox"
+        class="sr-custom-checkbox"
+        @change="handleVisibilityChanged"
+      />
+      <label for="historical-requests-toggle" class="control-label">Requests</label>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.sr-historical-requests-control {
+  background: color-mix(in srgb, var(--p-primary-color) 20%, transparent);
+  border: 1px solid var(--p-primary-color);
+  border-radius: var(--p-border-radius);
+  padding: 0 0.35rem;
+  height: 1.4rem;
+  display: flex;
+  align-items: center;
+}
+
+.sr-historical-requests-control:hover {
+  background: color-mix(in srgb, var(--p-primary-color) 80%, transparent);
+}
+
+.checkbox-container {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  cursor: pointer;
+}
+
+.control-label {
+  font-size: 0.7rem;
+  font-weight: 500;
+  color: black;
+  cursor: pointer;
+  user-select: none;
+  white-space: nowrap;
+  margin: 0;
+}
+
+.sr-custom-checkbox {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 0.85rem;
+  height: 0.85rem;
+  border: 1px solid var(--p-primary-color);
+  border-radius: 2px;
+  background: rgba(255, 255, 255, 0.3);
+  cursor: pointer;
+  position: relative;
+  margin: 0;
+  flex-shrink: 0;
+}
+
+.sr-custom-checkbox:hover {
+  background: rgba(255, 255, 255, 0.5);
+}
+
+.sr-custom-checkbox:checked {
+  background: rgba(255, 255, 255, 0.5);
+}
+
+.sr-custom-checkbox:checked::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -60%) rotate(45deg);
+  width: 0.2rem;
+  height: 0.4rem;
+  border: solid var(--p-primary-color);
+  border-width: 0 2px 2px 0;
+}
+</style>

--- a/web-client/src/components/SrMap.vue
+++ b/web-client/src/components/SrMap.vue
@@ -50,6 +50,7 @@ import { format } from 'ol/coordinate.js'
 import SrViewControl from './SrViewControl.vue'
 import SrBaseLayerControl from './SrBaseLayerControl.vue'
 import SrGraticuleControl from './SrGraticuleControl.vue'
+import SrHistoricalRequestsControl from './SrHistoricalRequestsControl.vue'
 import SrDrawControl from '@/components/SrDrawControl.vue'
 import { usePolarOverlay } from '@/composables/usePolarOverlay'
 import SrRasterizeControl from '@/components/SrRasterizeControl.vue'
@@ -1090,6 +1091,15 @@ function handleGraticuleControlCreated(graticuleControl: any) {
   }
 }
 
+function handleHistoricalRequestsControlCreated(control: any) {
+  const map = mapRef.value?.map
+  if (map) {
+    map.addControl(control)
+  } else {
+    logger.error('Map is null in handleHistoricalRequestsControlCreated')
+  }
+}
+
 function handleUploadRegionControlCreated(uploadControl: any) {
   const map = mapRef.value?.map
   if (map) {
@@ -1578,7 +1588,8 @@ watch(
 
       map.on('click', dropPinClickListener)
     } else {
-      recordsLayer.setVisible(true) // Show records layer when not dropping pin
+      // Restore records layer visibility, but respect the user's toggle preference
+      recordsLayer.setVisible(mapStore.historicalPolysVisible)
       targetElement.style.cursor = ''
       if (dropPinClickListener) {
         map.un('click', dropPinClickListener)
@@ -1586,6 +1597,15 @@ watch(
       }
     }
   }
+)
+watch(
+  () => mapStore.historicalPolysVisible,
+  (visible) => {
+    recordsLayer.setVisible(visible)
+    // Force pin layer to re-evaluate styles so historical pins (req_id > 0) hide/show
+    pinVectorLayer.changed()
+  },
+  { immediate: true }
 )
 watch(
   () => reqParamsStore.atl13.coord,
@@ -1667,6 +1687,9 @@ watch(
           @update-baselayer="handleUpdateBaseLayer"
         />
         <SrGraticuleControl @graticule-control-created="handleGraticuleControlCreated" />
+        <SrHistoricalRequestsControl
+          @historical-requests-control-created="handleHistoricalRequestsControlCreated"
+        />
         <SrUploadRegionControl
           v-if="reqParamsStore.iceSat2SelectedAPI != 'atl13x'"
           :reportUploadProgress="true"
@@ -1932,6 +1955,14 @@ watch(
 :deep(.ol-control.sr-graticule-control) {
   top: auto;
   bottom: 2.5rem;
+  right: auto;
+  left: 0.5rem;
+  border-radius: var(--p-border-radius);
+}
+
+:deep(.ol-control.sr-historical-requests-control) {
+  top: auto;
+  bottom: 4.25rem;
   right: auto;
   left: 0.5rem;
   border-radius: var(--p-border-radius);

--- a/web-client/src/components/SrMap.vue
+++ b/web-client/src/components/SrMap.vue
@@ -1954,7 +1954,7 @@ watch(
 
 :deep(.ol-control.sr-graticule-control) {
   top: auto;
-  bottom: 2.5rem;
+  bottom: 4.25rem;
   right: auto;
   left: 0.5rem;
   border-radius: var(--p-border-radius);
@@ -1962,7 +1962,7 @@ watch(
 
 :deep(.ol-control.sr-historical-requests-control) {
   top: auto;
-  bottom: 4.25rem;
+  bottom: 2.5rem;
   right: auto;
   left: 0.5rem;
   border-radius: var(--p-border-radius);

--- a/web-client/src/stores/mapStore.ts
+++ b/web-client/src/stores/mapStore.ts
@@ -81,6 +81,8 @@ export const useMapStore = defineStore('map', {
     plink: usePermalink(),
     // Restore graticule state from localStorage, default to false
     graticuleState: localStorage.getItem('graticuleState') === 'true',
+    // Restore historical request polygon visibility from localStorage, default to true
+    historicalPolysVisible: localStorage.getItem('historicalPolysVisible') !== 'false',
     // Store graticule instances per map (request map and analysis map need separate instances)
     graticules: new Map<OLMap, Graticule>(),
     polygonSource: 'Draw on Map' as string,
@@ -187,6 +189,10 @@ export const useMapStore = defineStore('map', {
       // Persist to localStorage
       localStorage.setItem('graticuleState', String(state))
       this.setGraticuleForMap()
+    },
+    setHistoricalPolysVisible(state: boolean) {
+      this.historicalPolysVisible = state
+      localStorage.setItem('historicalPolysVisible', String(state))
     },
     getOrCreateGraticule(map: OLMap): Graticule {
       // Get existing graticule for this map, or create a new one

--- a/web-client/src/utils/SrMapUtils.ts
+++ b/web-client/src/utils/SrMapUtils.ts
@@ -1395,6 +1395,12 @@ export function makePinStyleFunction(
   return (_feature: FeatureLike, _resolution: number): Style => {
     const zoom = map.getView().getZoom()
     const reqId = (_feature as any).get('req_id')
+    // Hide historical pins (req_id > 0) when the user has toggled them off.
+    // The live drop-pin has no req_id property, so it's never affected.
+    const isHistorical = typeof reqId === 'number' && reqId > 0
+    if (isHistorical && !useMapStore().historicalPolysVisible) {
+      return new Style({})
+    }
     const showPin = useReqParamsStore().useAtl13Point || (zoom && zoom >= minZoomToShowPin)
     return new Style({
       image: showPin


### PR DESCRIPTION
## Summary

- Closes #1062. Adds a **Requests** checkbox control to the world map that hides historical AOI polygons, their reqId labels, region masks, and ATL13 historical pins. Live drop-pin and the in-progress drawing are unaffected.
- State persists in `localStorage` (key: `historicalPolysVisible`); defaults to **on** so existing users see no behavior change.
- Drop-pin restoration now respects the toggle — no more snap-back to visible after a drop.

## Implementation

- New [`SrHistoricalRequestsControl.vue`](web-client/src/components/SrHistoricalRequestsControl.vue) — mirrors the existing `SrGraticuleControl` pattern.
- New `historicalPolysVisible` state + `setHistoricalPolysVisible` action in [`mapStore.ts`](web-client/src/stores/mapStore.ts).
- [`SrMap.vue`](web-client/src/components/SrMap.vue) watches the flag and toggles `recordsLayer.setVisible(...)` plus a `pinVectorLayer.changed()` to force restyle. Records and Pin layers are positioned in the bottom-left corner (Grid on top, Requests below).
- [`SrMapUtils.ts`](web-client/src/utils/SrMapUtils.ts) — `makePinStyleFunction` returns an empty Style for historical pins (`req_id > 0`) when the flag is off; the live drop-pin (no `req_id`) is untouched.

Two pre-existing failures noticed during implementation are tracked in #1063 (SrAppBar TS errors + GEDI `resources` round-trip tests). They are unrelated and predate this branch.

## Test plan

- [x] `make typecheck` — only pre-existing SrAppBar errors (#1063).
- [x] `make lint` — 0 errors, 17 warnings (all pre-existing in unrelated files).
- [x] `make test-unit` — 179 pass / 2 fail; failures are the pre-existing GEDI tests in #1063.
- [x] `make preview` smoke test:
  - [x] Polys + reqId labels render on world map by default.
  - [x] Toggle off → polys, labels, region masks all vanish; toggle on → all return.
  - [x] Reload preserves toggle state.
  - [x] Drop-pin with toggle off does not snap records layer back to visible.
  - [x] In-progress drawing remains visible regardless of toggle.
- [ ] Reviewer to verify ATL13 historical pin is also hidden when an ATL13 request exists in their local history (couldn't confirm in my local data).

🤖 Generated with [Claude Code](https://claude.com/claude-code)