### PR TITLE
Fix RangeError when selecting 3D plot (#1067)

### DIFF
--- a/web-client/src/utils/deck3DPlotUtils.ts
+++ b/web-client/src/utils/deck3DPlotUtils.ts
@@ -328,7 +328,6 @@ export async function loadAndCachePointCloudData(reqId: number) {
   //console.log(`Loading new data for reqId ${reqId}...`);
 
   try {
-    const fieldStore = useFieldNameStore()
     const fileName = await indexedDb.getFilename(reqId)
     if (!fileName) throw new Error('Filename not found')
 
@@ -418,38 +417,6 @@ export async function loadAndCachePointCloudData(reqId: number) {
       lastLoadedReqId = reqId
       verticalExaggerationInitialized = false // Reset flag for new data
       //console.log(`Cached ${cachedRawData.length} valid data points.`);
-
-      if (cachedRawData.length > 0) {
-        latField = fieldStore.getLatFieldName(reqId)
-        lonField = fieldStore.getLonFieldName(reqId)
-        heightField = fieldStore.getHFieldName(reqId)
-
-        // Compute min/max
-        let elevMin = Infinity,
-          elevMax = -Infinity
-        let latMin = Infinity,
-          latMax = -Infinity
-        let lonMin = Infinity,
-          lonMax = -Infinity
-
-        for (const row of cachedRawData) {
-          const lat = row[latField]
-          const lon = row[lonField]
-          const elev = row[heightField]
-          if (typeof lat === 'number' && isFinite(lat)) {
-            latMin = Math.min(latMin, lat)
-            latMax = Math.max(latMax, lat)
-          }
-          if (typeof lon === 'number' && isFinite(lon)) {
-            lonMin = Math.min(lonMin, lon)
-            lonMax = Math.max(lonMax, lon)
-          }
-          if (typeof elev === 'number' && isFinite(elev)) {
-            elevMin = Math.min(elevMin, elev)
-            elevMax = Math.max(elevMax, elev)
-          }
-        }
-      }
     } else {
       cachedRawData = []
       lastLoadedReqId = null
@@ -532,11 +499,19 @@ export function renderCachedData(deckContainer: Ref<HTMLDivElement | null>) {
   const elevMinData = getPercentile(elevations, minElDataPercent)
   const elevMaxData = getPercentile(elevations, maxElDataPercent)
 
-  // geographic bounds (degrees)
-  const lonMin = Math.min(...cachedRawData.map((d) => d[lonField]))
-  const lonMax = Math.max(...cachedRawData.map((d) => d[lonField]))
-  const latMin = Math.min(...cachedRawData.map((d) => d[latField]))
-  const latMax = Math.max(...cachedRawData.map((d) => d[latField]))
+  // geographic bounds (degrees) — single pass to avoid call-stack overflow on large arrays
+  let lonMin = Infinity
+  let lonMax = -Infinity
+  let latMin = Infinity
+  let latMax = -Infinity
+  for (const d of cachedRawData) {
+    const lon = d[lonField]
+    const lat = d[latField]
+    if (lon < lonMin) lonMin = lon
+    if (lon > lonMax) lonMax = lon
+    if (lat < latMin) latMin = lat
+    if (lat > latMax) latMax = lat
+  }
   const lonMid = 0.5 * (lonMin + lonMax)
   const latMid = 0.5 * (latMin + latMax)
 


### PR DESCRIPTION
## Summary
- Fixes #1067 — `RangeError: Maximum call stack size exceeded` when selecting the 3D plot, leaving the deck.gl canvas blank.
- Root cause: `renderCachedData` computed lon/lat bounds via `Math.min(...cachedRawData.map(...))` (×4). The spread pushes every point as a function argument and overflows the V8 argument-count limit (~65k–125k) for large point clouds.
- Replaced with a single-pass `for` loop. Also removed a dead bounds-computation block in `loadAndCachePointCloudData` whose results were never read (plus the unused inner `fieldStore` shadow it relied on).

## Test plan
- [ ] Open a request large enough to previously reproduce the crash, switch to the 3D view, and verify the point cloud renders without the `Maximum call stack size exceeded` console error.
- [ ] Open a small request and confirm the 3D view still renders correctly (axes, colors, hover, selection highlight).
- [ ] `make typecheck` ✅ (already passes locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)