### PR TITLE
Decouple plot and map point caps (#1070)

### DIFF
--- a/web-client/src/components/SrAnalysisMap.vue
+++ b/web-client/src/components/SrAnalysisMap.vue
@@ -453,6 +453,12 @@ function handleSampleCancel() {
   // Stay in show-all mode
 }
 
+function resetMaxNumPntsToDisplay() {
+  // Clear any "Show All" override and restore the persisted cap to the default
+  savedMaxPntsLimit.value = null
+  srParquetCfgStore.setMaxNumPntsToDisplay(DEFAULT_MAX_NUM_PNTS_TO_DISPLAY)
+}
+
 const offFilterTooltip = computed(() => {
   if (atlChartFilterStore.showPhotonCloud) {
     return 'This is disabled when Show Photon Cloud is enabled'
@@ -1114,6 +1120,15 @@ function handleSaveTooltip() {
           class="sr-show-all-btn"
           @click="handleToggleShowAllPoints"
         />
+        <Button
+          icon="pi pi-refresh"
+          class="sr-max-pnts-reset"
+          variant="text"
+          rounded
+          size="small"
+          title="Reset map point limit to default"
+          @click="resetMaxNumPntsToDisplay"
+        />
       </div>
       <div class="sr-notLoadingEl" v-else>
         {{ computedLoadMsg }}
@@ -1125,6 +1140,15 @@ function handleSaveTooltip() {
           size="small"
           class="sr-show-all-btn"
           @click="handleToggleShowAllPoints"
+        />
+        <Button
+          icon="pi pi-refresh"
+          class="sr-max-pnts-reset"
+          variant="text"
+          rounded
+          size="small"
+          title="Reset map point limit to default"
+          @click="resetMaxNumPntsToDisplay"
         />
       </div>
       <!-- DEBUG: Zoom level display -->
@@ -1605,6 +1629,14 @@ function handleSaveTooltip() {
   padding: 0.1rem 0.4rem;
   height: 1.4rem;
   min-width: auto;
+}
+.sr-max-pnts-reset {
+  padding: 0.125rem;
+  margin-left: 0.25rem;
+}
+.sr-max-pnts-reset :deep(.p-icon),
+.sr-max-pnts-reset :deep(.pi) {
+  font-size: 0.75rem;
 }
 .sr-threshold-slider-row {
   display: flex;

--- a/web-client/src/components/SrDeck3DView.vue
+++ b/web-client/src/components/SrDeck3DView.vue
@@ -66,6 +66,18 @@
         @update:model-value="handleVerticalExaggerationChange"
       />
     </div>
+    <div>
+      <label class="sr-num-pnts-label" for="numPntsId">Num Pnts</label>
+      <InputNumber
+        v-model="srParquetCfgStore.maxNumPntsToDisplay"
+        inputId="numPntsId"
+        size="small"
+        :step="10000"
+        :min="10000"
+        :max="5000000"
+        showButtons
+      />
+    </div>
   </div>
   <SrDeck3DCfg />
 </template>
@@ -87,8 +99,10 @@ import {
   updateFovy,
   transformLatLonTo3DWorld,
   is3DDataLoaded,
-  isTransformCacheReady
+  isTransformCacheReady,
+  invalidatePointCloudCache
 } from '@/utils/deck3DPlotUtils'
+import { useSrParquetCfgStore } from '@/stores/srParquetCfgStore'
 import { useGlobalChartStore } from '@/stores/globalChartStore'
 import { debouncedRender } from '@/utils/SrDebounce'
 import { yColorEncodeSelectedReactive } from '@/utils/plotUtils'
@@ -104,6 +118,7 @@ const chartStore = useChartStore()
 const toast = useSrToastStore()
 const deck3DConfigStore = useDeck3DConfigStore()
 const globalChartStore = useGlobalChartStore()
+const srParquetCfgStore = useSrParquetCfgStore()
 const reqId = computed(() => recTreeStore.selectedReqId)
 const elevationStore = useElevationColorMapStore()
 const computedFunc = computed(() => recTreeStore.selectedApi)
@@ -191,6 +206,17 @@ watch(reqId, async (newVal, oldVal) => {
     debouncedRender(localDeckContainer) // Use the fast, debounced renderer
   }
 })
+
+watch(
+  () => srParquetCfgStore.maxNumPntsToDisplay,
+  async (newVal, oldVal) => {
+    if (newVal === oldVal) return
+    logger.debug('maxNumPntsToDisplay changed, reloading 3D point cloud', { oldVal, newVal })
+    invalidatePointCloudCache()
+    await loadAndCachePointCloudData(reqId.value)
+    debouncedRender(localDeckContainer)
+  }
+)
 
 watch(
   () => deck3DConfigStore.fovy,
@@ -338,6 +364,12 @@ watch(
   justify-content: center;
 }
 .sr-vert-exag-label {
+  font-size: small;
+  margin-right: 0.2rem;
+  align-items: center;
+  justify-content: center;
+}
+.sr-num-pnts-label {
   font-size: small;
   margin-right: 0.2rem;
   align-items: center;

--- a/web-client/src/components/SrElevationPlot.vue
+++ b/web-client/src/components/SrElevationPlot.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import { use } from 'echarts/core'
 import ToggleButton from 'primevue/togglebutton'
+import InputNumber from 'primevue/inputnumber'
+import { DEFAULT_MAX_NUM_PNTS_TO_DISPLAY } from '@/stores/srParquetCfgStore'
 import { CanvasRenderer } from 'echarts/renderers'
 import { ScatterChart } from 'echarts/charts'
 import { CustomChart } from 'echarts/charts'
@@ -176,6 +178,9 @@ const props = defineProps({
 const requestsStore = useRequestsStore()
 const chartStore = useChartStore()
 const globalChartStore = useGlobalChartStore()
+function resetMaxPntsOnPlot() {
+  globalChartStore.max_pnts_on_plot = DEFAULT_MAX_NUM_PNTS_TO_DISPLAY
+}
 const atlChartFilterStore = useAtlChartFilterStore()
 const recTreeStore = useRecTreeStore()
 const analysisMapStore = useAnalysisMapStore()
@@ -1676,7 +1681,35 @@ watch(
             size="small"
             :tooltipText="'Show linear fit for each segment'"
           />
-          <label for="sslCheckbox" class="sr-checkbox-label">linear fit</label>
+          <label for="sslCheckbox" class="sr-checkbox-label">Linear Fit</label>
+        </div>
+        <div class="sr-max-pnts-row">
+          <span class="sr-max-pnts-readout"
+            >Pnts: {{ globalChartStore.num_pnts_on_plot.toLocaleString() }}</span
+          >
+          <label class="sr-max-pnts-label" for="maxPntsOnPlotId">Max</label>
+          <InputNumber
+            class="sr-max-pnts-input"
+            v-model="globalChartStore.max_pnts_on_plot"
+            inputId="maxPntsOnPlotId"
+            size="small"
+            :step="10000"
+            :min="10000"
+            :max="5000000"
+            showButtons
+            buttonLayout="horizontal"
+            incrementButtonIcon="pi pi-plus"
+            decrementButtonIcon="pi pi-minus"
+          />
+          <Button
+            icon="pi pi-refresh"
+            class="sr-max-pnts-reset"
+            variant="text"
+            rounded
+            size="small"
+            title="Reset to default"
+            @click="resetMaxPntsOnPlot"
+          />
         </div>
         <SrRunControl
           v-if="
@@ -1983,6 +2016,47 @@ watch(
   flex-direction: row;
   align-items: center; /* vertical centering */
   margin-left: 0.25rem;
+}
+
+.sr-max-pnts-row {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 0.25rem;
+  margin-left: 0.5rem;
+}
+
+.sr-max-pnts-readout {
+  font-size: 0.875rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.sr-max-pnts-label {
+  font-size: 0.875rem;
+}
+
+.sr-max-pnts-input :deep(.p-inputnumber-input) {
+  width: 5rem;
+}
+
+.sr-max-pnts-input :deep(.p-inputnumber-button) {
+  width: 1.25rem;
+  min-width: 1.25rem;
+  padding: 0;
+}
+
+.sr-max-pnts-input :deep(.p-inputnumber-button .p-icon),
+.sr-max-pnts-input :deep(.p-inputnumber-button .pi) {
+  font-size: 0.6rem;
+}
+
+.sr-max-pnts-reset {
+  padding: 0.125rem;
+}
+
+.sr-max-pnts-reset :deep(.p-icon),
+.sr-max-pnts-reset :deep(.pi) {
+  font-size: 0.75rem;
 }
 
 .sr-checkbox-label {

--- a/web-client/src/components/SrPlotConfig.vue
+++ b/web-client/src/components/SrPlotConfig.vue
@@ -210,6 +210,15 @@ watch(
     }
   }
 )
+
+watch(
+  () => globalChartStore.max_pnts_on_plot,
+  async (newVal, oldVal) => {
+    if (newVal === oldVal) return
+    logger.debug('max_pnts_on_plot changed, refreshing plot', { oldVal, newVal })
+    await callPlotUpdateDebounced('max_pnts_on_plot changed')
+  }
+)
 </script>
 <template>
   <Fieldset

--- a/web-client/src/stores/globalChartStore.ts
+++ b/web-client/src/stores/globalChartStore.ts
@@ -10,581 +10,596 @@ import { DEFAULT_MAX_NUM_PNTS_TO_DISPLAY } from '@/stores/srParquetCfgStore'
 
 const logger = createLogger('GlobalChartStore')
 
-export const useGlobalChartStore = defineStore('globalChartStore', () => {
-  const fontSize = ref<number>(16) // Default font size in pixels
-  const cycleOptions = ref<SrListNumberItem[]>([])
-  const selectedCycleOptions = ref<SrListNumberItem[]>([])
-  const filteredCycleOptions = ref<SrListNumberItem[]>([]) // subset for selected
-  const rgtOptions = ref<SrListNumberItem[]>([])
-  const selectedRgtOption = ref<SrListNumberItem>()
-  const selectedSpots = ref<number[]>([])
-  const selectedTrackOptions = ref<SrListNumberItem[]>([])
-  const selectedGtOptions = ref<SrListNumberItem[]>([])
-  const selectedPairOptions = ref<SrListNumberItem[]>([])
-  const filteredPairOptions = ref<SrListNumberItem[]>([]) // subset for selected
-  const scrollX = ref<number>(0)
-  const scrollY = ref<number>(0)
-  const hasScForward = ref<boolean>(false)
-  const hasScBackward = ref<boolean>(false)
-  const selectedElevationRec = ref<ElevationDataItem | null>(null)
-  const use_y_atc_filter = ref<boolean>(false)
-  const use_rgt_in_filter = ref<boolean>(true)
-  const enableLocationFinder = ref<boolean>(true)
-  const locationFinderLat = ref<number>(0.0)
-  const locationFinderLon = ref<number>(0.0)
-  const mapHoverLat = ref<number | null>(null)
-  const mapHoverLon = ref<number | null>(null)
-  const mapHoverActive = ref<boolean>(false)
-  const mapHoverIsSelected = ref<boolean>(false) // true if hovered point is on selected track
-  const selected_y_atc = ref<number>(0.0)
-  const y_atc_margin = ref<number>(50.0)
-  const max_pnts_on_plot = ref<number>(DEFAULT_MAX_NUM_PNTS_TO_DISPLAY)
-  const chunk_size_for_plot = ref<number>(10000)
-  const titleOfElevationPlot = ref<string>('Highlighted Track(s)') // Default title for the elevation plot
-  const allColumnMinMaxValues = ref<MinMaxLowHigh>({})
-  const usePercentileRange = ref<boolean>(false)
-  const useMapLegendFullRange = ref<boolean>(true)
-  const showPlotTooltip = ref<boolean>(false)
-  const useTimeForXAxis = ref<boolean>(false)
+export const useGlobalChartStore = defineStore(
+  'globalChartStore',
+  () => {
+    const fontSize = ref<number>(16) // Default font size in pixels
+    const cycleOptions = ref<SrListNumberItem[]>([])
+    const selectedCycleOptions = ref<SrListNumberItem[]>([])
+    const filteredCycleOptions = ref<SrListNumberItem[]>([]) // subset for selected
+    const rgtOptions = ref<SrListNumberItem[]>([])
+    const selectedRgtOption = ref<SrListNumberItem>()
+    const selectedSpots = ref<number[]>([])
+    const selectedTrackOptions = ref<SrListNumberItem[]>([])
+    const selectedGtOptions = ref<SrListNumberItem[]>([])
+    const selectedPairOptions = ref<SrListNumberItem[]>([])
+    const filteredPairOptions = ref<SrListNumberItem[]>([]) // subset for selected
+    const scrollX = ref<number>(0)
+    const scrollY = ref<number>(0)
+    const hasScForward = ref<boolean>(false)
+    const hasScBackward = ref<boolean>(false)
+    const selectedElevationRec = ref<ElevationDataItem | null>(null)
+    const use_y_atc_filter = ref<boolean>(false)
+    const use_rgt_in_filter = ref<boolean>(true)
+    const enableLocationFinder = ref<boolean>(true)
+    const locationFinderLat = ref<number>(0.0)
+    const locationFinderLon = ref<number>(0.0)
+    const mapHoverLat = ref<number | null>(null)
+    const mapHoverLon = ref<number | null>(null)
+    const mapHoverActive = ref<boolean>(false)
+    const mapHoverIsSelected = ref<boolean>(false) // true if hovered point is on selected track
+    const selected_y_atc = ref<number>(0.0)
+    const y_atc_margin = ref<number>(50.0)
+    const max_pnts_on_plot = ref<number>(DEFAULT_MAX_NUM_PNTS_TO_DISPLAY)
+    const num_pnts_on_plot = ref<number>(0)
+    const chunk_size_for_plot = ref<number>(10000)
+    const titleOfElevationPlot = ref<string>('Highlighted Track(s)') // Default title for the elevation plot
+    const allColumnMinMaxValues = ref<MinMaxLowHigh>({})
+    const usePercentileRange = ref<boolean>(false)
+    const useMapLegendFullRange = ref<boolean>(true)
+    const showPlotTooltip = ref<boolean>(false)
+    const useTimeForXAxis = ref<boolean>(false)
 
-  // State for zooming map to plot extent
-  const zoomToPlotExtent = ref<boolean>(false)
-  const plotLatLonExtent = ref<{
-    minLat: number
-    maxLat: number
-    minLon: number
-    maxLon: number
-  } | null>(null)
+    // State for zooming map to plot extent
+    const zoomToPlotExtent = ref<boolean>(false)
+    const plotLatLonExtent = ref<{
+      minLat: number
+      maxLat: number
+      minLon: number
+      maxLon: number
+    } | null>(null)
 
-  // State for storing current map view extent (for zooming plot to map extent)
-  const mapLatLonExtent = ref<{
-    minLat: number
-    maxLat: number
-    minLon: number
-    maxLon: number
-  } | null>(null)
+    // State for storing current map view extent (for zooming plot to map extent)
+    const mapLatLonExtent = ref<{
+      minLat: number
+      maxLat: number
+      minLon: number
+      maxLon: number
+    } | null>(null)
 
-  function setCycleOptions(newCycleOptions: SrListNumberItem[]) {
-    cycleOptions.value = newCycleOptions
-  }
-
-  function getCycleOptions(): SrListNumberItem[] {
-    return cycleOptions.value
-  }
-
-  function getCycleOptionsValues(): number[] {
-    return cycleOptions.value.map((cycle) => cycle.value)
-  }
-
-  function findCycleOption(cycle: number): SrListNumberItem | undefined {
-    return cycleOptions.value.find((option) => option.value === cycle)
-  }
-
-  function setCycles(cycles: number[]) {
-    if (!Array.isArray(cycles)) {
-      logger.error('setCycles received invalid cycles', { cycles })
-      selectedCycleOptions.value = []
-      return
+    function setCycleOptions(newCycleOptions: SrListNumberItem[]) {
+      cycleOptions.value = newCycleOptions
     }
-    const updatedCycleOptions = cycles.map((cycle) => {
-      return findCycleOption(cycle) || { label: cycle.toString(), value: cycle }
-    })
-    setSelectedCycleOptions(updatedCycleOptions)
-    //console.log('setCycles cycles:', cycles, ' selectedCycleOptions:', selectedCycleOptions.value);
-  }
 
-  function getCycles(): number[] {
-    if (!Array.isArray(selectedCycleOptions.value)) {
-      logger.error('getCycles: selectedCycleOptions is not an array', {
-        selectedCycleOptions: selectedCycleOptions.value
+    function getCycleOptions(): SrListNumberItem[] {
+      return cycleOptions.value
+    }
+
+    function getCycleOptionsValues(): number[] {
+      return cycleOptions.value.map((cycle) => cycle.value)
+    }
+
+    function findCycleOption(cycle: number): SrListNumberItem | undefined {
+      return cycleOptions.value.find((option) => option.value === cycle)
+    }
+
+    function setCycles(cycles: number[]) {
+      if (!Array.isArray(cycles)) {
+        logger.error('setCycles received invalid cycles', { cycles })
+        selectedCycleOptions.value = []
+        return
+      }
+      const updatedCycleOptions = cycles.map((cycle) => {
+        return findCycleOption(cycle) || { label: cycle.toString(), value: cycle }
       })
-      return []
+      setSelectedCycleOptions(updatedCycleOptions)
+      //console.log('setCycles cycles:', cycles, ' selectedCycleOptions:', selectedCycleOptions.value);
     }
-    return selectedCycleOptions.value.map((cycle) => cycle.value)
-  }
 
-  function setSelectedCycleOptions(cycleOptions: SrListNumberItem[]) {
-    if (!Array.isArray(cycleOptions)) {
-      logger.error('setSelectedCycleOptions received invalid cycleOptions', { cycleOptions })
-      selectedCycleOptions.value = []
-      return
+    function getCycles(): number[] {
+      if (!Array.isArray(selectedCycleOptions.value)) {
+        logger.error('getCycles: selectedCycleOptions is not an array', {
+          selectedCycleOptions: selectedCycleOptions.value
+        })
+        return []
+      }
+      return selectedCycleOptions.value.map((cycle) => cycle.value)
     }
-    selectedCycleOptions.value = cycleOptions
-    //console.log('setSelectedCycleOptions cycleOptions:', cycleOptions, ' selectedCycleOptions:', selectedCycleOptions.value);
-  }
 
-  function getSelectedCycleOptions(): SrListNumberItem[] {
-    return selectedCycleOptions.value
-  }
+    function setSelectedCycleOptions(cycleOptions: SrListNumberItem[]) {
+      if (!Array.isArray(cycleOptions)) {
+        logger.error('setSelectedCycleOptions received invalid cycleOptions', { cycleOptions })
+        selectedCycleOptions.value = []
+        return
+      }
+      selectedCycleOptions.value = cycleOptions
+      //console.log('setSelectedCycleOptions cycleOptions:', cycleOptions, ' selectedCycleOptions:', selectedCycleOptions.value);
+    }
 
-  function getMaxSelectedCycle(): number {
-    if (!Array.isArray(selectedCycleOptions.value) || selectedCycleOptions.value.length === 0) {
-      logger.error('getMaxSelectedCycle: selectedCycleOptions is not an array or is empty', {
-        selectedCycleOptions: selectedCycleOptions.value
+    function getSelectedCycleOptions(): SrListNumberItem[] {
+      return selectedCycleOptions.value
+    }
+
+    function getMaxSelectedCycle(): number {
+      if (!Array.isArray(selectedCycleOptions.value) || selectedCycleOptions.value.length === 0) {
+        logger.error('getMaxSelectedCycle: selectedCycleOptions is not an array or is empty', {
+          selectedCycleOptions: selectedCycleOptions.value
+        })
+        return -1
+      }
+      return Math.max(...selectedCycleOptions.value.map((cycle) => cycle.value))
+    }
+
+    function getMinSelectedCycle(): number {
+      if (!Array.isArray(selectedCycleOptions.value) || selectedCycleOptions.value.length === 0) {
+        logger.error('getMinSelectedCycle: selectedCycleOptions is not an array or is empty', {
+          selectedCycleOptions: selectedCycleOptions.value
+        })
+        return -1
+      }
+      return Math.min(...selectedCycleOptions.value.map((cycle) => cycle.value))
+    }
+
+    function getFilteredCycleOptions(): SrListNumberItem[] {
+      return filteredCycleOptions.value
+    }
+
+    function setFilteredCycleOptions(cycleOptions: SrListNumberItem[]) {
+      filteredCycleOptions.value = cycleOptions
+    }
+
+    function setRgtOptions(newRgtOptions: SrListNumberItem[]) {
+      rgtOptions.value = newRgtOptions
+      //console.trace('setRgtOptions rgtOptions:', newRgtOptions, ' selectedRgtOption:', selectedRgtOption.value);
+    }
+
+    function getRgtOptions(): SrListNumberItem[] {
+      return rgtOptions.value
+    }
+
+    function setSelectedRgtOptions(rgtOptions: SrListNumberItem[]): void {
+      if (!Array.isArray(rgtOptions)) {
+        logger.error('setSelectedRgtOptions received invalid rgtOptions', { rgtOptions })
+        selectedRgtOption.value = undefined
+        return
+      }
+      selectedRgtOption.value = rgtOptions.find((option) => option.value === getRgt()) || {
+        label: 'None',
+        value: -1
+      }
+      //console.log('setSelectedRgtOptions rgtOptions:', rgtOptions, ' selectedRgtOption:', selectedRgtOption.value);
+      if (selectedRgtOption.value === undefined) {
+        logger.error('setSelectedRgtOptions: selectedRgtOption is undefined', {
+          selectedRgtOption: selectedRgtOption.value
+        })
+        selectedRgtOption.value = { label: 'None', value: -1 }
+      }
+      //console.log('setSelectedRgtOptions rgtOptions:', rgtOptions, ' selectedRgtOption:', selectedRgtOption.value);
+    }
+
+    function findRgtOption(rgt: number): SrListNumberItem | undefined {
+      return rgtOptions.value.find((option) => option.value === rgt)
+    }
+
+    function setRgt(rgtOption: number) {
+      selectedRgtOption.value = findRgtOption(rgtOption) || {
+        label: rgtOption.toString(),
+        value: rgtOption
+      }
+      //console.log('setRgts rgts:', rgtOptions, ' selectedRgtOption:', selectedRgtOption.value);
+    }
+
+    function getRgt(): number {
+      const rgtOption = selectedRgtOption?.value
+      //console.log('getRgt rgtOption:', rgtOption, ' selectedRgtOptions:', selectedRgtOption.value);
+      return rgtOption ? rgtOption.value : -1
+    }
+
+    function setSpots(spots: number[]) {
+      if (!Array.isArray(spots)) {
+        logger.error('setSpots received invalid spots', { spots })
+        selectedSpots.value = []
+        return
+      }
+      selectedSpots.value = spots
+    }
+
+    function getSpots(): number[] {
+      if (!Array.isArray(selectedSpots.value)) {
+        logger.error('getSpots: selectedSpots is not an array', {
+          selectedSpots: selectedSpots.value
+        })
+        return []
+      }
+      return selectedSpots.value
+    }
+
+    function setTracks(tracks: number[]) {
+      if (!Array.isArray(tracks)) {
+        logger.error('setTracks received invalid tracks', { tracks })
+        selectedTrackOptions.value = []
+        return
+      }
+      const updatedTrackOptions = tracks.map((track) => {
+        return (
+          tracksOptions.find((option) => option.value === track) || {
+            label: track.toString(),
+            value: track
+          }
+        )
       })
-      return -1
+      selectedTrackOptions.value = updatedTrackOptions
+      //console.log('setTracks tracks:', tracks, ' selectedTrackOptions:', selectedTrackOptions.value);
     }
-    return Math.max(...selectedCycleOptions.value.map((cycle) => cycle.value))
-  }
 
-  function getMinSelectedCycle(): number {
-    if (!Array.isArray(selectedCycleOptions.value) || selectedCycleOptions.value.length === 0) {
-      logger.error('getMinSelectedCycle: selectedCycleOptions is not an array or is empty', {
-        selectedCycleOptions: selectedCycleOptions.value
+    function getTracksOptions(): SrListNumberItem[] {
+      return tracksOptions
+    }
+
+    function getTracks(): number[] {
+      if (!Array.isArray(selectedTrackOptions.value)) {
+        logger.error('getTracks: selectedTrackOptions is not an array', {
+          selectedTrackOptions: selectedTrackOptions.value
+        })
+        return []
+      }
+      return selectedTrackOptions.value.map((track) => track.value)
+    }
+
+    function getSelectedTrackOptions(): SrListNumberItem[] {
+      return selectedTrackOptions.value
+    }
+
+    function setGts(gts: number[]) {
+      if (!Array.isArray(gts)) {
+        logger.error('setGts received invalid gts', { gts })
+        selectedGtOptions.value = []
+        return
+      }
+      selectedGtOptions.value = gts.map((gt) => {
+        return (
+          gtsOptions.find((option) => option.value === gt) || { label: gt.toString(), value: gt }
+        )
       })
-      return -1
+      //console.log('setGts gts:', gts, ' selectedGtOptions:', selectedGtOptions.value);
     }
-    return Math.min(...selectedCycleOptions.value.map((cycle) => cycle.value))
-  }
 
-  function getFilteredCycleOptions(): SrListNumberItem[] {
-    return filteredCycleOptions.value
-  }
-
-  function setFilteredCycleOptions(cycleOptions: SrListNumberItem[]) {
-    filteredCycleOptions.value = cycleOptions
-  }
-
-  function setRgtOptions(newRgtOptions: SrListNumberItem[]) {
-    rgtOptions.value = newRgtOptions
-    //console.trace('setRgtOptions rgtOptions:', newRgtOptions, ' selectedRgtOption:', selectedRgtOption.value);
-  }
-
-  function getRgtOptions(): SrListNumberItem[] {
-    return rgtOptions.value
-  }
-
-  function setSelectedRgtOptions(rgtOptions: SrListNumberItem[]): void {
-    if (!Array.isArray(rgtOptions)) {
-      logger.error('setSelectedRgtOptions received invalid rgtOptions', { rgtOptions })
-      selectedRgtOption.value = undefined
-      return
+    function getGts(): number[] {
+      if (!Array.isArray(selectedGtOptions.value)) {
+        logger.error('getGts: selectedGtOptions is not an array', {
+          selectedGtOptions: selectedGtOptions.value
+        })
+        return []
+      }
+      return selectedGtOptions.value.map((gt) => gt.value)
     }
-    selectedRgtOption.value = rgtOptions.find((option) => option.value === getRgt()) || {
-      label: 'None',
-      value: -1
+
+    function getGtsOptions(): SrListNumberItem[] {
+      return gtsOptions
     }
-    //console.log('setSelectedRgtOptions rgtOptions:', rgtOptions, ' selectedRgtOption:', selectedRgtOption.value);
-    if (selectedRgtOption.value === undefined) {
-      logger.error('setSelectedRgtOptions: selectedRgtOption is undefined', {
-        selectedRgtOption: selectedRgtOption.value
+
+    function appendToSelectedGtOptions(gt: SrListNumberItem) {
+      const beamExists = selectedGtOptions.value.some((b) => b.value === gt.value)
+      if (!beamExists) {
+        selectedGtOptions.value.push(gt)
+      }
+    }
+
+    function setSelectedGtOptions(gtOptions: SrListNumberItem[]) {
+      if (!Array.isArray(gtOptions)) {
+        logger.error('setSelectedGtOptions received invalid gtOptions', { gtOptions })
+        selectedGtOptions.value = []
+        return
+      }
+      selectedGtOptions.value = gtOptions
+    }
+
+    function getSelectedGtOptions(): SrListNumberItem[] {
+      return selectedGtOptions.value
+    }
+
+    function getGtLabels(): string[] {
+      return selectedGtOptions.value.map((gt) => gt.label)
+    }
+
+    function setFilterWithSpotAndGt(spot: number, gt: number): void {
+      const sc_orient = getScOrientFromSpotAndGt(spot, gt)
+      setScOrients([sc_orient])
+      const details = getDetailsFromSpotNumber(spot)
+      setSpots([spot])
+      setGts([gt])
+      setTracks([details[sc_orient].track])
+      setPairs([details[sc_orient].pair])
+    }
+
+    function setTracksForGts(input_gts: SrListNumberItem[]) {
+      const tracks = input_gts
+        .map((gt) => tracksOptions.find((track) => Number(gt.label.charAt(2)) === track.value))
+        .filter((track): track is SrListNumberItem => track !== undefined)
+      const trkList = tracks.map((track) => track.value)
+      //console.log('setTracksForGts:',input_gts, 'tracks:', trkList);
+      setTracks(trkList)
+    }
+
+    function setGtsForTracks(input_tracks: number[]) {
+      const gts = input_tracks
+        .map((track) =>
+          gtsOptions.find((option) => Number(track) === Number(option.label.charAt(2)))
+        )
+        .filter((gt): gt is SrListNumberItem => gt !== undefined)
+      setSelectedGtOptions(gts)
+    }
+
+    function setPairs(pairs: number[]) {
+      if (!Array.isArray(pairs)) {
+        logger.error('setPairs received invalid pairs', { pairs })
+        selectedPairOptions.value = []
+        return
+      }
+      selectedPairOptions.value = pairs.map((pair) => {
+        return (
+          pairOptions.find((option) => option.value === pair) || {
+            label: pair.toString(),
+            value: pair
+          }
+        )
       })
-      selectedRgtOption.value = { label: 'None', value: -1 }
     }
-    //console.log('setSelectedRgtOptions rgtOptions:', rgtOptions, ' selectedRgtOption:', selectedRgtOption.value);
-  }
 
-  function findRgtOption(rgt: number): SrListNumberItem | undefined {
-    return rgtOptions.value.find((option) => option.value === rgt)
-  }
-
-  function setRgt(rgtOption: number) {
-    selectedRgtOption.value = findRgtOption(rgtOption) || {
-      label: rgtOption.toString(),
-      value: rgtOption
+    function getSelectedPairOptions(): SrListNumberItem[] {
+      return selectedPairOptions.value
     }
-    //console.log('setRgts rgts:', rgtOptions, ' selectedRgtOption:', selectedRgtOption.value);
-  }
 
-  function getRgt(): number {
-    const rgtOption = selectedRgtOption?.value
-    //console.log('getRgt rgtOption:', rgtOption, ' selectedRgtOptions:', selectedRgtOption.value);
-    return rgtOption ? rgtOption.value : -1
-  }
-
-  function setSpots(spots: number[]) {
-    if (!Array.isArray(spots)) {
-      logger.error('setSpots received invalid spots', { spots })
-      selectedSpots.value = []
-      return
+    function getPairs(): number[] {
+      return selectedPairOptions.value.map((pair) => pair.value)
     }
-    selectedSpots.value = spots
-  }
 
-  function getSpots(): number[] {
-    if (!Array.isArray(selectedSpots.value)) {
-      logger.error('getSpots: selectedSpots is not an array', {
-        selectedSpots: selectedSpots.value
-      })
-      return []
+    function getFilteredPairOptions(): SrListNumberItem[] {
+      return filteredPairOptions.value
     }
-    return selectedSpots.value
-  }
 
-  function setTracks(tracks: number[]) {
-    if (!Array.isArray(tracks)) {
-      logger.error('setTracks received invalid tracks', { tracks })
-      selectedTrackOptions.value = []
-      return
+    function setFilteredPairOptions(pairOptions: SrListNumberItem[]) {
+      filteredPairOptions.value = pairOptions
     }
-    const updatedTrackOptions = tracks.map((track) => {
+
+    function setSelectedPairOptions(pairOptions: SrListNumberItem[]) {
+      if (!Array.isArray(pairOptions)) {
+        logger.error('setSelectedPairOptions received invalid pairOptions', { pairOptions })
+        selectedPairOptions.value = []
+        return
+      }
+      selectedPairOptions.value = pairOptions
+    }
+
+    function appendPair(pair: number) {
+      selectedPairOptions.value.push({ label: pair.toString(), value: pair })
+    }
+
+    function setScOrients(scOrients: number[]) {
+      hasScForward.value = scOrients.includes(SC_FORWARD)
+      hasScBackward.value = scOrients.includes(SC_BACKWARD)
+    }
+
+    function getScOrients(): number[] {
+      const scOrients = []
+      if (hasScForward.value) {
+        scOrients.push(SC_FORWARD)
+      }
+      if (hasScBackward.value) {
+        scOrients.push(SC_BACKWARD)
+      }
+      return scOrients
+    }
+
+    function getScOrientsLabels(): string[] {
+      const scOrientLabels = []
+      if (hasScForward.value) {
+        scOrientLabels.push('Forward')
+      }
+      if (hasScBackward.value) {
+        scOrientLabels.push('Backward')
+      }
+      return scOrientLabels
+    }
+
+    const setSelectedElevationRec = (rec: ElevationDataItem): void => {
+      selectedElevationRec.value = rec
+    }
+
+    const getSelectedElevationRec = (): ElevationDataItem | null => {
+      return selectedElevationRec.value ?? null
+    }
+
+    function y_atc_is_valid(): boolean {
       return (
-        tracksOptions.find((option) => option.value === track) || {
-          label: track.toString(),
-          value: track
-        }
+        selected_y_atc.value != undefined &&
+        selected_y_atc.value != null &&
+        !isNaN(selected_y_atc.value)
       )
-    })
-    selectedTrackOptions.value = updatedTrackOptions
-    //console.log('setTracks tracks:', tracks, ' selectedTrackOptions:', selectedTrackOptions.value);
-  }
-
-  function getTracksOptions(): SrListNumberItem[] {
-    return tracksOptions
-  }
-
-  function getTracks(): number[] {
-    if (!Array.isArray(selectedTrackOptions.value)) {
-      logger.error('getTracks: selectedTrackOptions is not an array', {
-        selectedTrackOptions: selectedTrackOptions.value
-      })
-      return []
     }
-    return selectedTrackOptions.value.map((track) => track.value)
-  }
 
-  function getSelectedTrackOptions(): SrListNumberItem[] {
-    return selectedTrackOptions.value
-  }
+    function generateNameSuffix(req_id: number | string): string {
+      const rgt = getRgt()
+      const cycles = getCycles()
+      const spots = getSpots()
+      const min_y_atc = selected_y_atc.value - y_atc_margin.value
+      const max_y_atc = selected_y_atc.value + y_atc_margin.value
+      const min_y_atc_str = min_y_atc !== undefined ? min_y_atc.toFixed(2) : ''
+      const max_y_atc_str = max_y_atc !== undefined ? max_y_atc.toFixed(2) : ''
+      let nameSuffix = `-${req_id}-${rgt}-${cycles.join('-')}-${spots.join('-')}`
 
-  function setGts(gts: number[]) {
-    if (!Array.isArray(gts)) {
-      logger.error('setGts received invalid gts', { gts })
-      selectedGtOptions.value = []
-      return
+      if (use_y_atc_filter.value && min_y_atc !== undefined && max_y_atc !== undefined) {
+        nameSuffix += `-${min_y_atc_str}-${max_y_atc_str}`
+      }
+      return nameSuffix
     }
-    selectedGtOptions.value = gts.map((gt) => {
-      return gtsOptions.find((option) => option.value === gt) || { label: gt.toString(), value: gt }
-    })
-    //console.log('setGts gts:', gts, ' selectedGtOptions:', selectedGtOptions.value);
-  }
-
-  function getGts(): number[] {
-    if (!Array.isArray(selectedGtOptions.value)) {
-      logger.error('getGts: selectedGtOptions is not an array', {
-        selectedGtOptions: selectedGtOptions.value
-      })
-      return []
+    function setAllColumnMinMaxValues(values: MinMaxLowHigh) {
+      allColumnMinMaxValues.value = values
     }
-    return selectedGtOptions.value.map((gt) => gt.value)
-  }
 
-  function getGtsOptions(): SrListNumberItem[] {
-    return gtsOptions
-  }
-
-  function appendToSelectedGtOptions(gt: SrListNumberItem) {
-    const beamExists = selectedGtOptions.value.some((b) => b.value === gt.value)
-    if (!beamExists) {
-      selectedGtOptions.value.push(gt)
+    function getAllColumnMinMaxValues(): MinMaxLowHigh {
+      return allColumnMinMaxValues.value
     }
-  }
 
-  function setSelectedGtOptions(gtOptions: SrListNumberItem[]) {
-    if (!Array.isArray(gtOptions)) {
-      logger.error('setSelectedGtOptions received invalid gtOptions', { gtOptions })
-      selectedGtOptions.value = []
-      return
+    function getMin(column: string): number {
+      return allColumnMinMaxValues.value[column]?.min ?? undefined
     }
-    selectedGtOptions.value = gtOptions
-  }
-
-  function getSelectedGtOptions(): SrListNumberItem[] {
-    return selectedGtOptions.value
-  }
-
-  function getGtLabels(): string[] {
-    return selectedGtOptions.value.map((gt) => gt.label)
-  }
-
-  function setFilterWithSpotAndGt(spot: number, gt: number): void {
-    const sc_orient = getScOrientFromSpotAndGt(spot, gt)
-    setScOrients([sc_orient])
-    const details = getDetailsFromSpotNumber(spot)
-    setSpots([spot])
-    setGts([gt])
-    setTracks([details[sc_orient].track])
-    setPairs([details[sc_orient].pair])
-  }
-
-  function setTracksForGts(input_gts: SrListNumberItem[]) {
-    const tracks = input_gts
-      .map((gt) => tracksOptions.find((track) => Number(gt.label.charAt(2)) === track.value))
-      .filter((track): track is SrListNumberItem => track !== undefined)
-    const trkList = tracks.map((track) => track.value)
-    //console.log('setTracksForGts:',input_gts, 'tracks:', trkList);
-    setTracks(trkList)
-  }
-
-  function setGtsForTracks(input_tracks: number[]) {
-    const gts = input_tracks
-      .map((track) => gtsOptions.find((option) => Number(track) === Number(option.label.charAt(2))))
-      .filter((gt): gt is SrListNumberItem => gt !== undefined)
-    setSelectedGtOptions(gts)
-  }
-
-  function setPairs(pairs: number[]) {
-    if (!Array.isArray(pairs)) {
-      logger.error('setPairs received invalid pairs', { pairs })
-      selectedPairOptions.value = []
-      return
+    function getMax(column: string): number {
+      return allColumnMinMaxValues.value[column]?.max ?? undefined
     }
-    selectedPairOptions.value = pairs.map((pair) => {
-      return (
-        pairOptions.find((option) => option.value === pair) || {
-          label: pair.toString(),
-          value: pair
-        }
-      )
-    })
-  }
-
-  function getSelectedPairOptions(): SrListNumberItem[] {
-    return selectedPairOptions.value
-  }
-
-  function getPairs(): number[] {
-    return selectedPairOptions.value.map((pair) => pair.value)
-  }
-
-  function getFilteredPairOptions(): SrListNumberItem[] {
-    return filteredPairOptions.value
-  }
-
-  function setFilteredPairOptions(pairOptions: SrListNumberItem[]) {
-    filteredPairOptions.value = pairOptions
-  }
-
-  function setSelectedPairOptions(pairOptions: SrListNumberItem[]) {
-    if (!Array.isArray(pairOptions)) {
-      logger.error('setSelectedPairOptions received invalid pairOptions', { pairOptions })
-      selectedPairOptions.value = []
-      return
+    function getLow(column: string): number {
+      return allColumnMinMaxValues.value[column]?.low ?? undefined
     }
-    selectedPairOptions.value = pairOptions
-  }
-
-  function appendPair(pair: number) {
-    selectedPairOptions.value.push({ label: pair.toString(), value: pair })
-  }
-
-  function setScOrients(scOrients: number[]) {
-    hasScForward.value = scOrients.includes(SC_FORWARD)
-    hasScBackward.value = scOrients.includes(SC_BACKWARD)
-  }
-
-  function getScOrients(): number[] {
-    const scOrients = []
-    if (hasScForward.value) {
-      scOrients.push(SC_FORWARD)
+    function getHigh(column: string): number {
+      return allColumnMinMaxValues.value[column]?.high ?? undefined
     }
-    if (hasScBackward.value) {
-      scOrients.push(SC_BACKWARD)
+
+    function set_use_y_atc_filter(value: boolean) {
+      use_y_atc_filter.value = value
     }
-    return scOrients
-  }
 
-  function getScOrientsLabels(): string[] {
-    const scOrientLabels = []
-    if (hasScForward.value) {
-      scOrientLabels.push('Forward')
+    function setPlotLatLonExtent(
+      extent: { minLat: number; maxLat: number; minLon: number; maxLon: number } | null
+    ): void {
+      plotLatLonExtent.value = extent
+      if (extent) {
+        zoomToPlotExtent.value = true
+      }
     }
-    if (hasScBackward.value) {
-      scOrientLabels.push('Backward')
+
+    function resetZoomToPlotExtent(): void {
+      zoomToPlotExtent.value = false
     }
-    return scOrientLabels
-  }
 
-  const setSelectedElevationRec = (rec: ElevationDataItem): void => {
-    selectedElevationRec.value = rec
-  }
-
-  const getSelectedElevationRec = (): ElevationDataItem | null => {
-    return selectedElevationRec.value ?? null
-  }
-
-  function y_atc_is_valid(): boolean {
-    return (
-      selected_y_atc.value != undefined &&
-      selected_y_atc.value != null &&
-      !isNaN(selected_y_atc.value)
-    )
-  }
-
-  function generateNameSuffix(req_id: number | string): string {
-    const rgt = getRgt()
-    const cycles = getCycles()
-    const spots = getSpots()
-    const min_y_atc = selected_y_atc.value - y_atc_margin.value
-    const max_y_atc = selected_y_atc.value + y_atc_margin.value
-    const min_y_atc_str = min_y_atc !== undefined ? min_y_atc.toFixed(2) : ''
-    const max_y_atc_str = max_y_atc !== undefined ? max_y_atc.toFixed(2) : ''
-    let nameSuffix = `-${req_id}-${rgt}-${cycles.join('-')}-${spots.join('-')}`
-
-    if (use_y_atc_filter.value && min_y_atc !== undefined && max_y_atc !== undefined) {
-      nameSuffix += `-${min_y_atc_str}-${max_y_atc_str}`
+    function getPlotLatLonExtent(): {
+      minLat: number
+      maxLat: number
+      minLon: number
+      maxLon: number
+    } | null {
+      return plotLatLonExtent.value
     }
-    return nameSuffix
-  }
-  function setAllColumnMinMaxValues(values: MinMaxLowHigh) {
-    allColumnMinMaxValues.value = values
-  }
 
-  function getAllColumnMinMaxValues(): MinMaxLowHigh {
-    return allColumnMinMaxValues.value
-  }
+    function setMapLatLonExtent(
+      extent: { minLat: number; maxLat: number; minLon: number; maxLon: number } | null
+    ): void {
+      mapLatLonExtent.value = extent
+    }
 
-  function getMin(column: string): number {
-    return allColumnMinMaxValues.value[column]?.min ?? undefined
-  }
-  function getMax(column: string): number {
-    return allColumnMinMaxValues.value[column]?.max ?? undefined
-  }
-  function getLow(column: string): number {
-    return allColumnMinMaxValues.value[column]?.low ?? undefined
-  }
-  function getHigh(column: string): number {
-    return allColumnMinMaxValues.value[column]?.high ?? undefined
-  }
+    function getMapLatLonExtent(): {
+      minLat: number
+      maxLat: number
+      minLon: number
+      maxLon: number
+    } | null {
+      return mapLatLonExtent.value
+    }
 
-  function set_use_y_atc_filter(value: boolean) {
-    use_y_atc_filter.value = value
-  }
+    async function selectAllCycleOptions() {
+      //console.log('selectAllCycleOptions called');
+      await resetCycleOptions()
+      setSelectedCycleOptions(getCycleOptions())
+    }
 
-  function setPlotLatLonExtent(
-    extent: { minLat: number; maxLat: number; minLon: number; maxLon: number } | null
-  ): void {
-    plotLatLonExtent.value = extent
-    if (extent) {
-      zoomToPlotExtent.value = true
+    return {
+      fontSize,
+      getCycleOptions,
+      getCycleOptionsValues,
+      setCycleOptions,
+      findCycleOption,
+      selectAllCycleOptions,
+      cycleOptions,
+      setCycles,
+      getCycles,
+      setSelectedCycleOptions,
+      getSelectedCycleOptions,
+      selectedCycleOptions,
+      getFilteredCycleOptions,
+      setFilteredCycleOptions,
+      getMaxSelectedCycle,
+      getMinSelectedCycle,
+      setRgtOptions,
+      getRgtOptions,
+      setRgt,
+      getRgt,
+      selectedRgtOption,
+      setSelectedRgtOptions,
+      selectedSpots,
+      getSpots,
+      setSpots,
+      getTracksOptions,
+      getTracks,
+      setTracks,
+      getGts,
+      setGts,
+      getGtsOptions,
+      getGtLabels,
+      appendToSelectedGtOptions,
+      getSelectedGtOptions,
+      setSelectedGtOptions,
+      setFilterWithSpotAndGt,
+      setTracksForGts,
+      setGtsForTracks,
+      getSelectedTrackOptions,
+      setPairs,
+      getSelectedPairOptions,
+      getFilteredPairOptions,
+      setFilteredPairOptions,
+      setSelectedPairOptions,
+      appendPair,
+      getPairs,
+      setScOrients,
+      getScOrients,
+      getScOrientsLabels,
+      hasScForward,
+      hasScBackward,
+      scrollX,
+      scrollY,
+      titleOfElevationPlot,
+      setSelectedElevationRec,
+      getSelectedElevationRec,
+      use_y_atc_filter,
+      use_rgt_in_filter,
+      set_use_y_atc_filter,
+      selected_y_atc,
+      y_atc_is_valid,
+      y_atc_margin,
+      generateNameSuffix,
+      max_pnts_on_plot,
+      num_pnts_on_plot,
+      chunk_size_for_plot,
+      enableLocationFinder,
+      locationFinderLat,
+      locationFinderLon,
+      mapHoverLat,
+      mapHoverLon,
+      mapHoverActive,
+      mapHoverIsSelected,
+      allColumnMinMaxValues,
+      setAllColumnMinMaxValues,
+      getAllColumnMinMaxValues,
+      getMin,
+      getMax,
+      getLow,
+      getHigh,
+      usePercentileRange,
+      useMapLegendFullRange,
+      showPlotTooltip,
+      useTimeForXAxis,
+      zoomToPlotExtent,
+      plotLatLonExtent,
+      setPlotLatLonExtent,
+      resetZoomToPlotExtent,
+      getPlotLatLonExtent,
+      mapLatLonExtent,
+      setMapLatLonExtent,
+      getMapLatLonExtent
+    }
+  },
+  {
+    persist: {
+      storage: localStorage,
+      pick: ['max_pnts_on_plot']
     }
   }
-
-  function resetZoomToPlotExtent(): void {
-    zoomToPlotExtent.value = false
-  }
-
-  function getPlotLatLonExtent(): {
-    minLat: number
-    maxLat: number
-    minLon: number
-    maxLon: number
-  } | null {
-    return plotLatLonExtent.value
-  }
-
-  function setMapLatLonExtent(
-    extent: { minLat: number; maxLat: number; minLon: number; maxLon: number } | null
-  ): void {
-    mapLatLonExtent.value = extent
-  }
-
-  function getMapLatLonExtent(): {
-    minLat: number
-    maxLat: number
-    minLon: number
-    maxLon: number
-  } | null {
-    return mapLatLonExtent.value
-  }
-
-  async function selectAllCycleOptions() {
-    //console.log('selectAllCycleOptions called');
-    await resetCycleOptions()
-    setSelectedCycleOptions(getCycleOptions())
-  }
-
-  return {
-    fontSize,
-    getCycleOptions,
-    getCycleOptionsValues,
-    setCycleOptions,
-    findCycleOption,
-    selectAllCycleOptions,
-    cycleOptions,
-    setCycles,
-    getCycles,
-    setSelectedCycleOptions,
-    getSelectedCycleOptions,
-    selectedCycleOptions,
-    getFilteredCycleOptions,
-    setFilteredCycleOptions,
-    getMaxSelectedCycle,
-    getMinSelectedCycle,
-    setRgtOptions,
-    getRgtOptions,
-    setRgt,
-    getRgt,
-    selectedRgtOption,
-    setSelectedRgtOptions,
-    selectedSpots,
-    getSpots,
-    setSpots,
-    getTracksOptions,
-    getTracks,
-    setTracks,
-    getGts,
-    setGts,
-    getGtsOptions,
-    getGtLabels,
-    appendToSelectedGtOptions,
-    getSelectedGtOptions,
-    setSelectedGtOptions,
-    setFilterWithSpotAndGt,
-    setTracksForGts,
-    setGtsForTracks,
-    getSelectedTrackOptions,
-    setPairs,
-    getSelectedPairOptions,
-    getFilteredPairOptions,
-    setFilteredPairOptions,
-    setSelectedPairOptions,
-    appendPair,
-    getPairs,
-    setScOrients,
-    getScOrients,
-    getScOrientsLabels,
-    hasScForward,
-    hasScBackward,
-    scrollX,
-    scrollY,
-    titleOfElevationPlot,
-    setSelectedElevationRec,
-    getSelectedElevationRec,
-    use_y_atc_filter,
-    use_rgt_in_filter,
-    set_use_y_atc_filter,
-    selected_y_atc,
-    y_atc_is_valid,
-    y_atc_margin,
-    generateNameSuffix,
-    max_pnts_on_plot,
-    chunk_size_for_plot,
-    enableLocationFinder,
-    locationFinderLat,
-    locationFinderLon,
-    mapHoverLat,
-    mapHoverLon,
-    mapHoverActive,
-    mapHoverIsSelected,
-    allColumnMinMaxValues,
-    setAllColumnMinMaxValues,
-    getAllColumnMinMaxValues,
-    getMin,
-    getMax,
-    getLow,
-    getHigh,
-    usePercentileRange,
-    useMapLegendFullRange,
-    showPlotTooltip,
-    useTimeForXAxis,
-    zoomToPlotExtent,
-    plotLatLonExtent,
-    setPlotLatLonExtent,
-    resetZoomToPlotExtent,
-    getPlotLatLonExtent,
-    mapLatLonExtent,
-    setMapLatLonExtent,
-    getMapLatLonExtent
-  }
-})
+)

--- a/web-client/src/utils/SrDuckDb.ts
+++ b/web-client/src/utils/SrDuckDb.ts
@@ -299,12 +299,13 @@ export class DuckDBClient {
   async queryChunkSampled(
     query: string,
     random_sample_factor: number = 1, // Add random_sample_factor parameter, default is 1 (no sampling)
+    limit?: number, // explicit row cap; defaults to the map cap for backward compatibility
     params?: any
   ): Promise<QueryChunkResult> {
     //console.trace('SrDuckDb queryChunkSampled query:', query);
     const conn = await this._db!.connect()
     let tbl: Table<any>
-    const chunkSize = useSrParquetCfgStore().getMaxNumPntsToDisplay() // Default chunk size set to 100
+    const chunkSize = limit ?? useSrParquetCfgStore().getMaxNumPntsToDisplay()
     try {
       // Load spatial extension for this connection
       try {

--- a/web-client/src/utils/SrDuckDbUtils.ts
+++ b/web-client/src/utils/SrDuckDbUtils.ts
@@ -2146,10 +2146,13 @@ export async function fetchScatterData(
     //console.log('fetchScatterData totalRowCnt:', totalRowCnt, ' typeof:', typeof totalRowCnt);
     //console.log('fetchScatterData max_pnts_on_plot:', useGlobalChartStore().max_pnts_on_plot, ' typeof:', typeof useGlobalChartStore().max_pnts_on_plot);
 
-    const sample_fraction = useGlobalChartStore().max_pnts_on_plot / Number(totalRowCnt)
+    useGlobalChartStore().num_pnts_on_plot += Number(totalRowCnt)
+    const plotCap = useGlobalChartStore().max_pnts_on_plot
+    const sample_fraction = plotCap / Number(totalRowCnt)
     const queryResultMain: QueryResult = await duckDbClient.queryChunkSampled(
       useChartStore().getQuerySql(reqIdStr),
-      sample_fraction
+      sample_fraction,
+      plotCap
     )
     /**
      * 5. For each row, produce an array [ xVal, yVal1, yVal2, ..., extras ]

--- a/web-client/src/utils/deck3DPlotUtils.ts
+++ b/web-client/src/utils/deck3DPlotUtils.ts
@@ -155,6 +155,14 @@ export function is3DDataLoaded(): boolean {
 }
 
 /**
+ * Invalidate the cached point cloud so the next loadAndCachePointCloudData
+ * call performs a fresh query (e.g. after the sampling limit changes).
+ */
+export function invalidatePointCloudCache(): void {
+  lastLoadedReqId = null
+}
+
+/**
  * Check if the transform cache is populated (needed for coordinate transformation).
  * This is populated after renderCachedData() runs successfully.
  */

--- a/web-client/src/utils/plotUtils.ts
+++ b/web-client/src/utils/plotUtils.ts
@@ -1420,6 +1420,9 @@ const initScatterPlotWith = async (reqId: number) => {
     return
   }
 
+  // Reset combined row count; fetchScatterData accumulates per series (main + overlays)
+  useGlobalChartStore().num_pnts_on_plot = 0
+
   // Check if this is a new track (reqId changed) - if so, reset zoom
   if (atlChartFilterStore.lastReqId !== reqId) {
     logger.debug('New track detected - resetting zoom', {


### PR DESCRIPTION
## Summary
- Fixes #1070 — plot fetches were silently truncated by the map cap, producing rectangular cutoffs in photon-cloud overlays on long tracks.
- `queryChunkSampled` now takes an explicit `limit` parameter. `fetchScatterData` passes `max_pnts_on_plot`; map and 3D paths keep defaulting to the map cap. The two caps no longer leak into each other.

## Bundled cap-UX fixes
- `globalChartStore.max_pnts_on_plot` persisted to `localStorage`.
- Watcher in `SrPlotConfig` refreshes the plot when the cap changes.
- In-context **Max Pnts** control + live **Pnts:** readout in the elevation toolbar; readout is the combined pre-sample row count across main series and overlays (reset at plot init, accumulated per fetch).
- Reset-to-default buttons in the elevation toolbar and analysis-map header so users can recover from a runaway persisted cap.
- 3D view gains a **Num Pnts** control sharing the map cap, with a watcher that invalidates the deck.gl point-cloud cache and reloads.

## Test plan
- [ ] Open an ATL06 record, enable Show Photon Cloud, view elevation plot. Confirm overlay extends the full track length (no rectangular cutoff).
- [ ] Set plot cap to 250,000 with map cap at default 50,000. Confirm plot returns up to 250k rows; map continues to sample at 50k independently.
- [ ] Click the plot reset button — \`max_pnts_on_plot\` returns to 50,000.
- [ ] Click the map reset button — \`maxNumPntsToDisplay\` returns to 50,000 and any \`savedMaxPntsLimit\` override is cleared.
- [ ] Reload the page — \`max_pnts_on_plot\` is preserved.
- [ ] Switch to 3D view, change Num Pnts, confirm point cloud reloads. Confirm the analysis map's cap value also updates (they share state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)