### PR TITLE
Add "Zoom plot to map extent" button to Time Series tab

### DIFF
--- a/web-client/src/components/SrTimeSeries.vue
+++ b/web-client/src/components/SrTimeSeries.vue
@@ -14,6 +14,8 @@ import { provide, watch, onMounted, ref, computed, nextTick } from 'vue'
 import { useAtlChartFilterStore } from '@/stores/atlChartFilterStore'
 import { useChartStore } from '@/stores/chartStore'
 import { callPlotUpdateDebounced, checkAndSetFilterForTimeSeries } from '@/utils/plotUtils'
+import { getXRangeFromLatLonExtent } from '@/utils/SrDuckDbUtils'
+import { useSrToastStore } from '@/stores/srToastStore'
 import { useRecTreeStore } from '@/stores/recTreeStore'
 import { useActiveTabStore } from '@/stores/activeTabStore'
 import SrPlotCntrl from '@/components/SrPlotCntrl.vue'
@@ -195,6 +197,58 @@ function resetChartZoom() {
     })
   } catch (error) {
     logger.error('Error resetting chart zoom', { error })
+  }
+}
+
+// Computed to check if map extent data is available for zoom-plot-to-map feature
+const hasMapExtentData = computed(() => {
+  const mapExtent = globalChartStore.getMapLatLonExtent()
+  const selectedReqId = recTreeStore.selectedReqId
+  return !!(mapExtent && selectedReqId && selectedReqId > 0)
+})
+
+// Tooltip text for zoom-plot-to-map button
+const zoomPlotToMapTooltip = computed(() =>
+  hasMapExtentData.value ? 'Zoom plot to match visible map extent' : 'No map extent available'
+)
+
+// Handler for zoom-plot-to-map button
+async function handleZoomPlotToMapExtent() {
+  const selectedReqId = recTreeStore.selectedReqId
+  const mapExtent = globalChartStore.getMapLatLonExtent()
+
+  if (!hasMapExtentData.value || !selectedReqId || !mapExtent) {
+    logger.warn('handleZoomPlotToMapExtent: No map extent or reqId')
+    return
+  }
+
+  logger.debug('handleZoomPlotToMapExtent: Zooming plot to map extent', {
+    selectedReqId,
+    mapExtent
+  })
+
+  const xRange = await getXRangeFromLatLonExtent(selectedReqId, mapExtent)
+  if (xRange) {
+    // Set the chart zoom values
+    atlChartFilterStore.xZoomStartValue = xRange.xMin
+    atlChartFilterStore.xZoomEndValue = xRange.xMax
+    // Reset percentage values so value-based zoom takes precedence
+    atlChartFilterStore.xZoomStart = 0
+    atlChartFilterStore.xZoomEnd = 100
+
+    logger.debug('handleZoomPlotToMapExtent: Set zoom range', { xRange })
+
+    // Trigger chart update
+    if (chartStore.getSelectedYData(recTreeStore.selectedReqIdStr).length > 0) {
+      await callPlotUpdateDebounced('from handleZoomPlotToMapExtent')
+    }
+  } else {
+    logger.warn('handleZoomPlotToMapExtent: Could not get X range from map extent')
+    useSrToastStore().warn(
+      'No Data in Visible Map Area',
+      'Could not find data within the visible map extent. Try zooming out on the map.',
+      10000
+    )
   }
 }
 
@@ -452,6 +506,21 @@ watch(
               aria-label="Drag to Zoom"
               :class="['sr-glow-button', { 'sr-zoom-select-active': zoomSelectMode }]"
               @click="zoomSelectMode = !zoomSelectMode"
+            />
+          </div>
+          <div
+            @mouseover="tooltipRef.showTooltip($event, zoomPlotToMapTooltip)"
+            @mouseleave="tooltipRef.hideTooltip()"
+          >
+            <Button
+              icon="pi pi-map"
+              severity="secondary"
+              text
+              rounded
+              class="sr-glow-button"
+              aria-label="Zoom Plot to Map Extent"
+              :disabled="!hasMapExtentData"
+              @click="handleZoomPlotToMapExtent"
             />
           </div>
         </div>


### PR DESCRIPTION
## Summary

Closes #1077.

Adds the **"Zoom plot to match visible map extent"** control to the **Time Series** tab of the Analysis view. This is the mirror of the button that already exists on the **Elevation Plot** tab — it lets a user pan/zoom the map and then snap the time-series plot's x-axis to just the data inside the current map extent, streamlining the back-and-forth between map and profile.

### Background

The reverse-direction feature ("zoom plot to map extent") was added for the Elevation Plot tab in #848, but the Time Series tab is a separate component (`SrTimeSeries.vue`) with its own hand-maintained toolbar, so the button was never carried over. There was no deliberate guard excluding it — just an oversight. For the common atl06/atl03 repeat-track case the time-series x-axis is along-track distance (`x_atc`), so the same map-extent → x-range mapping applies identically.

### Changes (`web-client/src/components/SrTimeSeries.vue`)

- `pi pi-map` toolbar button (`aria-label="Zoom Plot to Map Extent"`), disabled until a request is selected and the map has reported an extent
- `handleZoomPlotToMapExtent()` handler, `hasMapExtentData` + `zoomPlotToMapTooltip` computeds — ported verbatim from `SrElevationPlot.vue`
- New imports: `getXRangeFromLatLonExtent` (SrDuckDbUtils) and `useSrToastStore`. All other machinery (`atlChartFilterStore`, `globalChartStore`, `callPlotUpdateDebounced`) was already imported by the component.

### Verification

Drove the production build through Playwright (Chromium) using the `importFile` fixture (atl03x, multi-cycle):

- Button renders on the Time Series tab (accessibility snapshot + locator), enabled when a map extent is available — parity with the Elevation Plot tab.
- Click → `handleZoomPlotToMapExtent` → `getXRangeFromLatLonExtent` (confirmed `xField: x_atc`) → sets zoom → `callPlotUpdateDebounced` → plot refresh. Verified via captured debug logs.
- Empty-result path: clicking with the map zoomed off-track shows the graceful "No Data in Visible Map Area" toast — same behavior as the Elevation Plot tab.

### Note

The button is also present for `atl13x` time series, whose x-axis is genuinely time. It remains wired there but its usefulness is less obvious; if we want to hide it for atl13x, the existing `notAtl13xTimeSeries` computed in the component can gate it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)