### PR TITLE
Fix TS2742 typecheck failure in deck3DConfigStore

### DIFF
--- a/web-client/src/stores/deck3DConfigStore.ts
+++ b/web-client/src/stores/deck3DConfigStore.ts
@@ -3,6 +3,19 @@ import { defineStore } from 'pinia'
 import { ref, reactive } from 'vue'
 import type { OrbitViewState } from '@deck.gl/core'
 
+// Portable shape for the live orbit view state we expose from this store.
+// We intentionally do NOT use OrbitViewState as the reactive() generic: reactive()
+// unwraps it structurally, which drags in @deck.gl/core's internal (non-exported)
+// transitions/transition type and trips TS2742 on the store's inferred public type.
+// OrbitViewState is still fine as a parameter type below since it's referenced by
+// its public name, not structurally expanded.
+interface Deck3DViewState {
+  target: number[]
+  zoom: number
+  rotationX: number
+  rotationOrbit: number
+}
+
 export const useDeck3DConfigStore = defineStore('deckConfig', () => {
   const deckContainer = ref<HTMLDivElement | null>(null)
 
@@ -41,7 +54,7 @@ export const useDeck3DConfigStore = defineStore('deckConfig', () => {
   const hoverMarkerScale = ref(2.0) // User-adjustable scale factor (percentage of data extent)
   // — LIVE VIEW STATE —
   // these will be updated in onViewStateChange
-  const viewState = reactive<OrbitViewState>({
+  const viewState = reactive<Deck3DViewState>({
     target: [...centroid.value],
     zoom: 5,
     rotationX: 45,


### PR DESCRIPTION
## Summary

Closes #1079.

`make typecheck` (`vue-tsc --noEmit -p tsconfig.app.json`) has been failing on `main`:

```
src/stores/deck3DConfigStore.ts(6,14): error TS2742: The inferred type of
'useDeck3DConfigStore' cannot be named without a reference to
'../../node_modules/@deck.gl/core/dist/transitions/transition'. This is likely
not portable. A type annotation is necessary.
```

### Root cause

`viewState` was declared as `reactive<OrbitViewState>(...)` and returned from the Pinia setup store. `reactive()` unwraps its generic **structurally** (`UnwrapNestedRefs<OrbitViewState>`), and that expansion pulls in `@deck.gl/core`'s internal, non-exported `transitions/transition` type. TypeScript then can't name the store's inferred public type portably → TS2742 (reported at the `defineStore` call on L6).

`make build` was unaffected (it runs `vite build` / esbuild only, no `vue-tsc`), so this never blocked deploys — but it kept the typecheck gate red and masked real regressions.

### Change (`web-client/src/stores/deck3DConfigStore.ts`)

- Added a local, portable `Deck3DViewState` interface covering the fields actually used (`target`, `zoom`, `rotationX`, `rotationOrbit`) and typed the reactive `viewState` with it instead of `OrbitViewState`.
- Kept `OrbitViewState` as the `updateViewState(vs)` parameter type — there it's referenced by its public name, not structurally expanded, so the deck.gl `onViewStateChange` callback in `deck3DPlotUtils.ts` still passes through unchanged.

Purely type-level; no runtime behavior change (the `reactive()` generic is erased at runtime and the object initializer is identical).

### Verification

- `make typecheck` → exits **0**; the whole project (including the deck.gl consumers `deck3DPlotUtils.ts` and `SrDeck3DCfg.vue`) typechecks.
- eslint + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)