### PR TITLE
Maintain web client release notes locally (#1081)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,10 @@ doctor: ## Check that your Node/npm versions match .nvmrc and the packageManager
 
 src-tag-and-push: ## Tag and push the web client source code to the repository
 	$(ROOT)/VITE_VERSION.sh $(VERSION) && git push --tags; git push
+	$(ROOT)/publish-gh-release.sh $(VERSION)
+
+gen-release-notes: ## Generate web-client release notes draft from git log NEEDS VERSION
+	$(ROOT)/gen-release-notes.sh $(VERSION)
 
 upload-assets: ## Upload hashed JS/CSS assets with long cache duration
 	export AWS_MAX_ATTEMPTS=10 AWS_RETRY_MODE=standard && \

--- a/README.md
+++ b/README.md
@@ -77,6 +77,63 @@ This project is designed to be deployed as a secure static site using Amazon Clo
 
 We use [HashiCorp Terraform](https://www.terraform.io/) to deploy this website.
 
+### Releasing
+
+The recommended workflow is to release a new tagged version to the test site first,
+sanity-check it, then promote that same build to production.
+
+**1. Tag and release to test** (requires `VERSION` in `vX.Y.Z` form):
+
+```bash
+make release-live-update-to-testsliderule VERSION=v4.5.3
+```
+
+This step does all the version-stamping work:
+
+1. **Generates and commits the release notes** for the version from the git commit
+   subjects since the previous tag, then creates and pushes the annotated `vX.Y.Z`
+   tag (`src-tag-and-push` → `VITE_VERSION.sh` → `gen-release-notes.sh`).
+2. **Mirrors the notes to a GitHub Release** (`publish-gh-release.sh`). This step is
+   non-fatal — if the `gh` CLI is missing or unauthenticated it warns and is skipped,
+   so it never blocks a deploy.
+3. **Builds and deploys** the client to **testsliderule.org** — the tag is injected
+   as `VITE_APP_VERSION`, assets are uploaded to S3, and CloudFront is invalidated.
+
+Sanity-check the result at <https://client.testsliderule.org>.
+
+**2. Promote the same tagged build to production:**
+
+```bash
+make live-update-slideruleearth
+```
+
+This rebuilds the current checkout and deploys it to **slideruleearth.io**. It does
+**not** create a new tag — the build reads the existing tag via `git describe --tags`,
+so the release notes and the GitHub Release are created exactly once, during step 1.
+
+> A one-shot `make release-live-update-to-slideruleearth VERSION=v4.5.3` also exists
+> (it tags and deploys straight to production), but the test-first workflow above is
+> recommended.
+
+### Release notes
+
+Web-client release notes are maintained in this repo as one Markdown file per
+version under `web-client/src/assets/content/release-notes/` (e.g. `v4.5.3.md`).
+They are bundled into the client at build time and shown in the **Web Client
+Releases** tab on the landing page (the **SlideRule Releases** tab continues to
+show the platform/server notes from the docs site).
+
+The release flow auto-generates a draft from the commits since the previous tag.
+To curate the notes before releasing, generate the draft first, edit it, then run
+the release (step 1 above) — an existing file is preserved (use `--force` to
+regenerate):
+
+```bash
+make gen-release-notes VERSION=v4.5.3   # writes .../release-notes/v4.5.3.md
+# edit the generated file...
+make release-live-update-to-testsliderule VERSION=v4.5.3
+```
+
 ## License
 
 This project is licensed under the following University of Washington Open Source License - see the [LICENSE](LICENSE) file for details.

--- a/VITE_VERSION.sh
+++ b/VITE_VERSION.sh
@@ -17,6 +17,21 @@ if git tag -l | grep -w $VERSION; then
 fi
 
 #
+# Generate (if missing) and commit the web-client release notes for this version
+# BEFORE tagging, so the tag — and the build, which reads the tag for
+# VITE_APP_VERSION — includes the notes file. A pre-existing file (e.g. one a
+# developer generated via `make gen-release-notes` and hand-edited) is preserved.
+#
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+NOTES_FILE="$ROOT_DIR/web-client/src/assets/content/release-notes/$VERSION.md"
+"$SCRIPT_DIR/gen-release-notes.sh" "$VERSION"
+git add "$NOTES_FILE"
+if ! git diff --cached --quiet -- "$NOTES_FILE"; then
+    git commit -m "Add release notes for $VERSION"
+fi
+
+#
 # Create tag and acrhive
 #
 git tag -a $VERSION -m "version $VERSION"

--- a/gen-release-notes.sh
+++ b/gen-release-notes.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+#
+# Generate a web-client release-notes markdown file for a given version,
+# derived from the git commit subjects since the previous tag.
+#
+# Usage:
+#   gen-release-notes.sh <vX.Y.Z> [--force]
+#
+# Writes web-client/src/assets/content/release-notes/<vX.Y.Z>.md
+# These files are bundled into the web client at build time (see LandingView.vue)
+# and mirrored to a GitHub Release at tag time (see publish-gh-release.sh).
+#
+# Idempotent: an existing file is left untouched unless --force is passed. This
+# lets a developer pre-generate the draft (`make gen-release-notes VERSION=...`),
+# hand-edit it, and have the tag flow preserve their edits.
+#
+set -euo pipefail
+
+VERSION="${1:-}"
+FORCE="${2:-}"
+
+if [[ "$VERSION" != "v"*"."*"."* ]]; then
+    echo "Usage: gen-release-notes.sh <vX.Y.Z> [--force]" >&2
+    echo "Invalid version number: '$VERSION'" >&2
+    exit 1
+fi
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+NOTES_DIR="$ROOT_DIR/web-client/src/assets/content/release-notes"
+NOTES_FILE="$NOTES_DIR/$VERSION.md"
+
+if [[ -f "$NOTES_FILE" && "$FORCE" != "--force" ]]; then
+    echo "Release notes already exist: $NOTES_FILE (use --force to regenerate)"
+    exit 0
+fi
+
+mkdir -p "$NOTES_DIR"
+
+# Previous tag — computed before the new tag is created. Falls back to the full
+# history when no tags exist yet (first release).
+PREV_TAG="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+if [[ -n "$PREV_TAG" ]]; then
+    RANGE="$PREV_TAG..HEAD"
+else
+    RANGE="HEAD"
+fi
+
+BODY="$(git log "$RANGE" --no-merges --pretty='- %s (%h)')"
+if [[ -z "$BODY" ]]; then
+    BODY="- No notable changes."
+fi
+
+DATE="$(date +%Y-%m-%d)"
+
+{
+    echo "# $VERSION — $DATE"
+    echo
+    echo "$BODY"
+} > "$NOTES_FILE"
+
+echo "Wrote $NOTES_FILE"

--- a/publish-gh-release.sh
+++ b/publish-gh-release.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+#
+# Mirror a web-client release-notes file to a GitHub Release.
+#
+# Usage:
+#   publish-gh-release.sh <vX.Y.Z>
+#
+# The committed markdown file remains the source of truth and is bundled into the
+# client; this just publishes the same notes to github.com so the Releases page
+# is populated. Run AFTER the tag has been pushed (see `src-tag-and-push`).
+#
+# This is intentionally non-fatal: a missing/unauthenticated `gh`, or a GitHub
+# API hiccup, must never break a deploy. It warns and exits 0 in those cases.
+#
+set -uo pipefail
+
+VERSION="${1:-}"
+
+if [[ "$VERSION" != "v"*"."*"."* ]]; then
+    echo "Usage: publish-gh-release.sh <vX.Y.Z>" >&2
+    echo "Invalid version number: '$VERSION'" >&2
+    exit 1
+fi
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+NOTES_FILE="$ROOT_DIR/web-client/src/assets/content/release-notes/$VERSION.md"
+
+if [[ ! -f "$NOTES_FILE" ]]; then
+    echo "WARNING: no release-notes file at $NOTES_FILE — skipping GitHub Release." >&2
+    exit 0
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+    echo "WARNING: 'gh' CLI not found — skipping GitHub Release for $VERSION." >&2
+    exit 0
+fi
+
+if ! gh auth status >/dev/null 2>&1; then
+    echo "WARNING: 'gh' not authenticated — skipping GitHub Release for $VERSION." >&2
+    exit 0
+fi
+
+# Update in place if the release already exists, otherwise create it.
+if gh release view "$VERSION" >/dev/null 2>&1; then
+    echo "Updating existing GitHub Release $VERSION..."
+    gh release edit "$VERSION" --title "$VERSION" --notes-file "$NOTES_FILE" \
+        || echo "WARNING: failed to update GitHub Release $VERSION (continuing)." >&2
+else
+    echo "Creating GitHub Release $VERSION..."
+    gh release create "$VERSION" --title "$VERSION" --notes-file "$NOTES_FILE" \
+        || echo "WARNING: failed to create GitHub Release $VERSION (continuing)." >&2
+fi
+
+exit 0

--- a/web-client/src/assets/content/release-notes/v4.4.4.md
+++ b/web-client/src/assets/content/release-notes/v4.4.4.md
@@ -1,0 +1,3 @@
+# v4.4.4 — 2026-05-13
+
+- Decouple plot and map point caps (#1070) (bd91a1b9)

--- a/web-client/src/assets/content/release-notes/v4.4.5.md
+++ b/web-client/src/assets/content/release-notes/v4.4.5.md
@@ -1,0 +1,7 @@
+# v4.4.5 — 2026-05-20
+
+- updated articles location to new docs path; added easter egg globe view (8c3c47c6)
+- polished global view (51a96c7c)
+- added atl18 skin to globe (81c68f43)
+- updated some bathy types that were fixed on the server side (ef4df7fd)
+- initial commit for globe (df5a4012)

--- a/web-client/src/assets/content/release-notes/v4.4.6.md
+++ b/web-client/src/assets/content/release-notes/v4.4.6.md
@@ -1,0 +1,4 @@
+# v4.4.6 — 2026-05-20
+
+- updated terraform lock file when deployment executed on linux machine (a04545b6)
+- added docs.slideruleearth.io as a trusted image src (c1f660ce)

--- a/web-client/src/assets/content/release-notes/v4.5.0.md
+++ b/web-client/src/assets/content/release-notes/v4.5.0.md
@@ -1,0 +1,3 @@
+# v4.5.0 — 2026-05-28
+
+- Scope advanced parameters to the selected endpoint (#1074) (3ef7669b)

--- a/web-client/src/assets/content/release-notes/v4.5.1.md
+++ b/web-client/src/assets/content/release-notes/v4.5.1.md
@@ -1,0 +1,4 @@
+# v4.5.1 — 2026-06-08
+
+- landing page release both web client and server release notes (7a16e4e2)
+- updated landing page to pull release notes instead of articles (fc23ef4f)

--- a/web-client/src/assets/content/release-notes/v4.5.2.md
+++ b/web-client/src/assets/content/release-notes/v4.5.2.md
@@ -1,0 +1,4 @@
+# v4.5.2 — 2026-06-09
+
+- Fix TS2742 typecheck failure in deck3DConfigStore (#1079) (b5249683)
+- Add "Zoom plot to map extent" button to Time Series tab (#1077) (c997a0e6)

--- a/web-client/src/utils/docLinks.ts
+++ b/web-client/src/utils/docLinks.ts
@@ -41,5 +41,9 @@ export const DOCS = {
   releaseNotes: {
     index: `${DOCS_BASE}/developer_guide/release_notes/release_notes.html`,
     base: `${DOCS_BASE}/developer_guide/release_notes/`
+  },
+  webClient: {
+    repo: 'https://github.com/SlideRuleEarth/sliderule-web-client',
+    tags: 'https://github.com/SlideRuleEarth/sliderule-web-client/releases/tag/'
   }
 } as const

--- a/web-client/src/views/LandingView.vue
+++ b/web-client/src/views/LandingView.vue
@@ -15,7 +15,7 @@ function stripFrontmatter(md: string): string {
 const aboutHtml = DOMPurify.sanitize(marked(stripFrontmatter(aboutRaw)) as string)
 const contactHtml = DOMPurify.sanitize(marked(stripFrontmatter(contactRaw)) as string)
 
-const tabOptions = ['About', 'Contact', 'Release Notes']
+const tabOptions = ['About', 'Contact', 'SlideRule Releases', 'Web Client Releases']
 const selectedTab = ref('About')
 
 const panelHtml = computed(() => {
@@ -30,6 +30,11 @@ const panelHtml = computed(() => {
 })
 
 // --- Release Notes ---
+//
+// Two release-note sources share the list/detail UI below:
+//  - 'remote' = the SlideRule platform notes scraped from the docs site
+//  - 'local'  = this repo's web-client notes, bundled at build time (see the
+//               import.meta.glob of src/assets/content/release-notes/*.md)
 
 const RELEASE_NOTES_INDEX_URL = DOCS.releaseNotes.index
 const RELEASE_NOTES_BASE_URL = DOCS.releaseNotes.base
@@ -37,8 +42,9 @@ const RELEASE_NOTES_BASE_URL = DOCS.releaseNotes.base
 interface ReleaseNote {
   title: string
   date: string
-  url: string
+  url: string // external link: docs page (remote) or GitHub release tag (local)
   snippet?: string
+  html?: string // precomputed detail HTML (local notes only)
 }
 
 const releaseNotes = ref<ReleaseNote[]>([])
@@ -46,6 +52,82 @@ const selectedRelease = ref<ReleaseNote | null>(null)
 const releaseHtml = ref('')
 const releaseLoading = ref(false)
 const releaseError = ref('')
+
+const releaseMode = computed<'remote' | 'local' | null>(() => {
+  if (selectedTab.value === 'SlideRule Releases') return 'remote'
+  if (selectedTab.value === 'Web Client Releases') return 'local'
+  return null
+})
+
+// --- Local web-client release notes (bundled markdown) ---
+
+const localNoteModules = import.meta.glob('@/assets/content/release-notes/*.md', {
+  query: '?raw',
+  import: 'default',
+  eager: true
+}) as Record<string, string>
+
+function versionKey(v: string): number[] {
+  return v
+    .replace(/^v/, '')
+    .split('.')
+    .map((n) => parseInt(n, 10) || 0)
+}
+
+// Sort newest-first by semantic version (v4.5.10 after v4.5.2).
+function compareVersionDesc(a: string, b: string): number {
+  const av = versionKey(a)
+  const bv = versionKey(b)
+  for (let i = 0; i < Math.max(av.length, bv.length); i++) {
+    const diff = (bv[i] ?? 0) - (av[i] ?? 0)
+    if (diff !== 0) return diff
+  }
+  return 0
+}
+
+const localReleaseNotes = computed<ReleaseNote[]>(() => {
+  const notes = Object.entries(localNoteModules).map(([path, raw]) => {
+    const version = path.split('/').pop()?.replace(/\.md$/, '') ?? ''
+    const body = stripFrontmatter(raw)
+    // First heading line, e.g. "# v4.5.2 — 2026-06-09"
+    const header = body.match(/^#\s+(\S+)\s+[—-]\s+(\d{4}-\d{2}-\d{2})/m)
+    const title = header?.[1] ?? version
+    const date = header?.[2] ?? ''
+    // First bullet line used as a one-line snippet in the list view.
+    const bullet = body.match(/^\s*[-*]\s+(.+)$/m)
+    const snippet = bullet?.[1] ?? ''
+    const html = DOMPurify.sanitize(marked(body) as string)
+    return { title, date, url: DOCS.webClient.tags + version, snippet, html }
+  })
+  return notes.sort((a, b) => compareVersionDesc(a.title, b.title) || b.date.localeCompare(a.date))
+})
+
+const currentNotes = computed<ReleaseNote[]>(() => {
+  if (releaseMode.value === 'local') return localReleaseNotes.value
+  if (releaseMode.value === 'remote') return releaseNotes.value
+  return []
+})
+
+const externalLink = computed(() => {
+  if (!selectedRelease.value) return ''
+  return releaseMode.value === 'local'
+    ? selectedRelease.value.url
+    : RELEASE_NOTES_BASE_URL + selectedRelease.value.url
+})
+
+const externalLinkLabel = computed(() =>
+  releaseMode.value === 'local' ? 'View on GitHub ↗' : 'View on docs site ↗'
+)
+
+function openRelease(note: ReleaseNote) {
+  if (releaseMode.value === 'local') {
+    // Local notes are already rendered — no network fetch needed.
+    selectedRelease.value = note
+    releaseHtml.value = note.html ?? ''
+  } else {
+    void fetchRelease(note)
+  }
+}
 
 async function fetchReleaseNotesIndex() {
   releaseLoading.value = true
@@ -155,8 +237,12 @@ onMounted(() => {
 })
 
 watch(selectedTab, (tab) => {
-  if (tab === 'Release Notes') {
-    selectedRelease.value = null
+  // Reset the detail view whenever the tab changes; only the remote source needs
+  // an on-switch fetch (local notes are bundled and rendered eagerly).
+  selectedRelease.value = null
+  releaseHtml.value = ''
+  releaseError.value = ''
+  if (tab === 'SlideRule Releases') {
     void fetchReleaseNotesIndex()
   }
 })
@@ -175,7 +261,7 @@ watch(selectedTab, (tab) => {
         </div>
       </div>
       <!-- About / Contact -->
-      <div v-if="selectedTab !== 'Release Notes'" ref="panelRef" class="sr-landing-panel">
+      <div v-if="releaseMode === null" ref="panelRef" class="sr-landing-panel">
         <div v-if="panelHtml" class="sr-landing-panel-content">
           <div v-html="panelHtml" />
         </div>
@@ -184,7 +270,7 @@ watch(selectedTab, (tab) => {
         </div>
       </div>
 
-      <!-- Release Notes -->
+      <!-- Release Notes (SlideRule platform = remote, Web Client = local) -->
       <div v-else class="sr-landing-panel">
         <div v-if="releaseLoading" class="sr-news-status">Loading...</div>
         <div v-else-if="releaseError" class="sr-news-status sr-news-error">{{ releaseError }}</div>
@@ -193,15 +279,15 @@ watch(selectedTab, (tab) => {
           <div v-html="releaseHtml" />
           <a
             class="sr-news-original-link"
-            :href="RELEASE_NOTES_BASE_URL + selectedRelease.url"
+            :href="externalLink"
             target="_blank"
             rel="noopener noreferrer"
           >
-            View on docs site ↗
+            {{ externalLinkLabel }}
           </a>
         </div>
-        <ul v-else class="sr-news-list">
-          <li v-for="r in releaseNotes" :key="r.url" @click="fetchRelease(r)">
+        <ul v-else-if="currentNotes.length" class="sr-news-list">
+          <li v-for="r in currentNotes" :key="r.url" @click="openRelease(r)">
             <span class="sr-news-date">{{ r.date }}</span>
             <div class="sr-news-body">
               <span class="sr-news-title">{{ r.title }}</span>
@@ -209,6 +295,7 @@ watch(selectedTab, (tab) => {
             </div>
           </li>
         </ul>
+        <div v-else class="sr-news-status">No release notes available.</div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Closes #1081.

Maintains web-client release notes **locally in this repo** — versioned with the code, bundled into the client, and shown in their own landing-page tab — instead of relying on the central SlideRule docs. Notes are generated from `git log` at tag time and mirrored to GitHub Releases.

## What changed

**Release-notes content**
- New `web-client/src/assets/content/release-notes/` with one Markdown file per version (`vX.Y.Z.md`), seeded with `v4.4.4`–`v4.5.2` backfilled from their real commit ranges + tag dates.

**UI** — [`LandingView.vue`](web-client/src/views/LandingView.vue)
- Tabs are now **About · Contact · SlideRule Releases · Web Client Releases**.
- *SlideRule Releases* keeps the existing remote docs scrape (platform/server notes).
- *Web Client Releases* (new) loads the bundled markdown via `import.meta.glob(... ?raw)` and reuses the existing `marked` + `DOMPurify` list→detail UI. Detail view links "View on GitHub ↗" to the release tag.
- [`docLinks.ts`](web-client/src/utils/docLinks.ts): added `webClient` repo/tags links.

**Tagging / release tooling**
- New [`gen-release-notes.sh`](gen-release-notes.sh): generates a version's notes from the commit subjects since the previous tag. Idempotent (preserves a hand-edited draft; `--force` to regenerate).
- New [`publish-gh-release.sh`](publish-gh-release.sh): mirrors the committed notes to a GitHub Release. **Non-fatal** — warns and skips if `gh` is missing/unauthenticated, so it never blocks a deploy.
- [`VITE_VERSION.sh`](VITE_VERSION.sh): generates + commits the notes file **before** creating the tag, so the tag (and the build's `VITE_APP_VERSION`) include it.
- [`Makefile`](Makefile): `src-tag-and-push` now calls `publish-gh-release.sh`; added a `gen-release-notes` target for curating a draft before release.

**Docs** — [`README.md`](README.md): documents the test-first release workflow (`release-live-update-to-testsliderule VERSION=…` → verify → `live-update-slideruleearth`) and how release notes are maintained.

## Release flow

```
make release-live-update-to-testsliderule VERSION=v4.5.3   # tag + gen/commit notes + GitHub Release + deploy to test
# verify on testsliderule.org
make live-update-slideruleearth                            # redeploy same tag to production (no re-tag)
```

The tag, the committed notes file, and the GitHub Release are created once (in the test step); production just rebuilds the existing tag.

## Verification

- `make typecheck` ✓ · `make lint` ✓ · `make test-unit` ✓ (194 passed) · `make build` ✓
- Confirmed the seeded notes text and the new tab label are bundled into the `LandingView` chunk.
- Generator dry-run, idempotency skip, and the `publish-gh-release.sh` non-fatal guard all exercised locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)