### PR TITLE
Fix atl24x photon-cloud overlay version handling (#1084)

### DIFF
--- a/web-client/src/components/SrElevationPlot.vue
+++ b/web-client/src/components/SrElevationPlot.vue
@@ -1130,7 +1130,7 @@ async function handlePhotonCloudShow() {
       )
       chartStore.setSelectedColorEncodeData(parentReqIdStr, 'solid')
       await initSymbolSize(runContext.reqId) // for new record
-      initializeColorEncoding(runContext.reqId, 'atl03x')
+      initializeColorEncoding(runContext.reqId, parentFuncStr)
       // The worker will now fetch the data from the server
       // and write the opfs file then update
       // the map selected layer and the chart

--- a/web-client/src/stores/reqParamsStore.ts
+++ b/web-client/src/stores/reqParamsStore.ts
@@ -506,9 +506,16 @@ const createReqParamsStore = (id: string) =>
           logger.error('Mission not recognized in getAtlReqParams', { mission: this.missionValue })
         }
 
-        // Add CMR version for ATL24 photon cloud overlay
+        // Pin the CMR ATL03 release to match the ATL24 product's input ATL03 version. ATL24
+        // granule names encode that version (ATL24 user guide §1.2.3), and we already carry it
+        // through in the derived resource name (ATL03_[date]_[ttttccss]_[VVV]_[RR].h5). Derive
+        // it from that resource rather than hardcoding, so the overlay tracks the ATL24 product
+        // automatically — e.g. when ATL24 is rebuilt against ATL03 R007, both the resource name
+        // and this version become '007' with no code change. (Note: this only works while the
+        // matching ATL03 release is still available to SlideRule in S3.)
         if (this.isAtl24PhotonOverlay && this.iceSat2SelectedAPI.includes('atl03')) {
-          req.cmr = { version: '006' }
+          const atl03Release = this.resources[0]?.split('_')[3]
+          req.cmr = { version: atl03Release || '006' }
         }
 
         if (this.iceSat2SelectedAPI.includes('atl03')) {

--- a/web-client/src/utils/plotUtils.ts
+++ b/web-client/src/utils/plotUtils.ts
@@ -129,7 +129,11 @@ export interface SrScatterSeriesData {
 
 export function getDefaultColorEncoding(reqId: number, parentFuncStr?: string) {
   if (reqId > 0) {
-    const func = useRecTreeStore().findApiForReqId(reqId)
+    // A photon-cloud overlay (signalled by parentFuncStr) is always an atl03x record.
+    // The rec tree may not yet contain a freshly-created overlay node — it is rebuilt
+    // asynchronously once the OPFS file is ready — so fall back to atl03x rather than
+    // emitting a misleading "solid" default and warning during that window.
+    const func = useRecTreeStore().findApiForReqId(reqId) || (parentFuncStr ? 'atl03x' : '')
     if (func) {
       const fieldNameStore = useFieldNameStore()
       // Special cases that use non-height field for color encoding


### PR DESCRIPTION
## What

Client-side follow-ups for the `atl24x` photon-cloud overlay (issue #1084).

The overlay re-fetches an `atl03x` request with `atl24` classification, deriving the source ATL03 granule name and CMR version from the parent ATL24 product (whose granule name encodes the input ATL03 release per NSIDC ATL24 User Guide §1.2.3).

## Changes

- **`reqParamsStore.ts`** — derive `cmr.version` from the derived resource name's version field (`ATL03_[date]_[ttttccss]_[VVV]_[RR].h5`) instead of hardcoding `"006"`. The overlay now tracks the ATL24 product automatically, so when the R007-based ATL24 run ships the request uses `"007"` with no code change.
- **`SrElevationPlot.vue` / `plotUtils.ts`** — color an `atl24x` overlay by `atl24_class` (pass the real parent func string rather than a hardcoded `"atl03x"`), and fall back to `atl03x` in `getDefaultColorEncoding` while the rec tree hasn't yet registered the freshly-created overlay node — removing a spurious `No function found for reqId, returning solid color encoding` warning.

## Important: this does not restore the photon cloud by itself

The current ATL24 product was built from ATL03 **R006**, and NSIDC removed the R006 ATL03 granules from S3 that SlideRule reads, so the overlay returns `NO_DATA` regardless of these changes. Confirmed external (not a client bug) by the SlideRule server developer (JP Swinski). Full resolution depends on:

- NSIDC restoring R006 ATL03 in S3, **or**
- the R007-based ATL24 run shipping (summer 2026), after which the `cmr.version` derivation above picks up `"007"` automatically.

Refs #1084 — leaving the issue open to track the external resolution.

## Testing

- `make typecheck` ✅
- `make lint` ✅
- Manual: verified the request now sends a CMR version matching the derived ATL03 granule; behavior on the live server still gated on R006/R007 availability as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
