### PR TITLE
Treat atl06sp as a subsetter, not photon-processing

### DIFF
--- a/web-client/src/components/SrAdvOptAccordion.vue
+++ b/web-client/src/components/SrAdvOptAccordion.vue
@@ -42,8 +42,10 @@ const expandedPanels = ref<number[]>([])
 const isPhotonProcessingAPI = computed(() => photonProcessingAPIs.has(props.iceSat2SelectedAPI))
 
 // Fixed segment dimensions baked into pre-computed ATL06/ATL08 data products.
-// Source: ICESat-2 ATL06 / ATL08 product specifications.
+// Source: ICESat-2 ATL06 / ATL08 product specifications. atl06sp is the parallel
+// ATL06 subsetter — same source segments as atl06x.
 const fixedExtentsByAPI: Record<string, { len: number; res: number }> = {
+  atl06sp: { len: 40, res: 20 },
   atl06x: { len: 40, res: 20 },
   atl08x: { len: 100, res: 100 }
 }
@@ -56,11 +58,12 @@ const fixedExtentsTooltip = computed(() => {
 })
 
 // Panels that show parameters used at request time are visible when the
-// selected endpoint actually consumes them. X-series endpoints read pre-computed
-// segments from the source HDF5 product so most photon-processing panels are hidden.
+// selected endpoint actually consumes them. Subsetter endpoints (atl06sp, atl06x,
+// atl08x, atl24x, atl13x) read pre-computed segments from the source HDF5
+// product so most photon-processing panels are hidden.
 const showExtentsPanel = computed(() => isPhotonProcessingAPI.value || fixedExtents.value !== null)
 const showSurfaceElevationPanel = computed(() =>
-  ['atl06p', 'atl06sp', 'atl03x-surface'].includes(props.iceSat2SelectedAPI)
+  ['atl06p', 'atl03x-surface'].includes(props.iceSat2SelectedAPI)
 )
 const showPhoRealPanel = computed(() =>
   ['atl08p', 'atl03x-phoreal'].includes(props.iceSat2SelectedAPI)

--- a/web-client/src/types/SrStaticOptions.ts
+++ b/web-client/src/types/SrStaticOptions.ts
@@ -28,15 +28,14 @@ export const iceSat2APIsItems = [
 export const gediAPIsItems = ['gedi01bp', 'gedi02ap', 'gedi04ap']
 // ICESat-2 endpoints that compute segments from ATL03 photons and accept
 // photon-processing parameters (cnf, srt, yapc, len, res, fit, etc.).
-// X-series endpoints (atl06x, atl08x, atl24x, atl13x) read pre-computed
-// segments from HDF5 files and ignore these parameters.
+// Subsetter endpoints (atl06sp, atl06x, atl08x, atl24x, atl13x) read
+// pre-computed segments from HDF5 files and ignore these parameters.
 export const photonProcessingAPIs: ReadonlySet<string> = new Set([
   'atl03x',
   'atl03x-surface',
   'atl03x-phoreal',
   'atl03vp',
   'atl06p',
-  'atl06sp',
   'atl08p'
 ])
 export const surfaceReferenceTypeOptions = [

--- a/web-client/tests/unit/endpointParamScoping.spec.ts
+++ b/web-client/tests/unit/endpointParamScoping.spec.ts
@@ -1,12 +1,14 @@
 /**
  * Unit tests for endpoint parameter scoping (Issue #1074)
  *
- * Verifies that X-series endpoints (atl06x, atl08x, atl24x, atl13x) do not
- * include photon-processing parameters in their requests, since they read
- * pre-computed segments from HDF5 files and the server ignores these params.
+ * Verifies that subsetter endpoints (atl06sp, atl06x, atl08x, atl24x, atl13x)
+ * do not include photon-processing parameters in their requests, since they
+ * read pre-computed segments from HDF5 files and the server ignores these
+ * params. atl06sp uses the same minimal Atl06Parameters class as atl06x —
+ * both call the atl06s subsetter under the hood.
  *
- * P-series endpoints (atl06p, atl03x, etc.) compute from ATL03 photons and
- * should include these parameters when enabled.
+ * Photon-processing endpoints (atl06p, atl03x, atl08p, etc.) compute from
+ * ATL03 photons and should include these parameters when enabled.
  */
 
 import { describe, it, expect, beforeEach } from 'vitest'
@@ -60,10 +62,10 @@ describe('Endpoint Parameter Scoping', () => {
     'cnt'
   ]
 
-  describe('X-series endpoints should exclude photon-processing params', () => {
-    const xSeriesAPIs = ['atl06x', 'atl08x', 'atl24x', 'atl13x']
+  describe('Subsetter endpoints should exclude photon-processing params', () => {
+    const subsetterAPIs = ['atl06sp', 'atl06x', 'atl08x', 'atl24x', 'atl13x']
 
-    xSeriesAPIs.forEach((api) => {
+    subsetterAPIs.forEach((api) => {
       it(`${api} request should not include photon-processing parameters`, () => {
         enableAllPhotonParams()
         store.iceSat2SelectedAPI = api
@@ -151,6 +153,16 @@ describe('Endpoint Parameter Scoping', () => {
 
       expect(req).toHaveProperty('atl06_fields', ['h_li_sigma'])
     })
+
+    it('atl06sp should include atl06_fields and the icesat2-atl06 asset', () => {
+      store.missionValue = 'ICESat-2'
+      store.iceSat2SelectedAPI = 'atl06sp'
+      store.atl06_fields = ['h_li_sigma']
+      const req = store.getAtlReqParams(1)
+
+      expect(req).toHaveProperty('atl06_fields', ['h_li_sigma'])
+      expect(req).toHaveProperty('asset', 'icesat2-atl06')
+    })
   })
 
   describe('Universal params work for all endpoints', () => {
@@ -168,24 +180,16 @@ describe('Endpoint Parameter Scoping', () => {
   })
 
   describe('photonProcessingAPIs set is correct', () => {
-    it('should contain all P-series and ATL03-based endpoints', () => {
-      const expected = [
-        'atl03x',
-        'atl03x-surface',
-        'atl03x-phoreal',
-        'atl03vp',
-        'atl06p',
-        'atl06sp',
-        'atl08p'
-      ]
+    it('should contain all endpoints that compute from ATL03 photons', () => {
+      const expected = ['atl03x', 'atl03x-surface', 'atl03x-phoreal', 'atl03vp', 'atl06p', 'atl08p']
       for (const api of expected) {
         expect(photonProcessingAPIs.has(api)).toBe(true)
       }
     })
 
-    it('should not contain X-series endpoints', () => {
-      const xSeries = ['atl06x', 'atl08x', 'atl24x', 'atl13x']
-      for (const api of xSeries) {
+    it('should not contain subsetter endpoints', () => {
+      const subsetters = ['atl06sp', 'atl06x', 'atl08x', 'atl24x', 'atl13x']
+      for (const api of subsetters) {
         expect(photonProcessingAPIs.has(api)).toBe(false)
       }
     })


### PR DESCRIPTION
## Summary
Follow-up fix to PR #1075 (issue #1074).

[`atl06sp`](https://github.com/SlideRuleEarth/sliderule/blob/main/datasets/icesat2/endpoints/atl06sp.lua) is the *parallel ATL06 subsetter*, not a photon-processing endpoint. Its server schema is [`Atl06Parameters`](https://github.com/SlideRuleEarth/sliderule/blob/main/datasets/icesat2/package/Atl06Parameters.h) (the minimal class, same as `atl06x`), and its main calls `proxy.proxy(resources, parms, "atl06s", ...)` — running the `atl06s` runner which reads pre-computed ATL06 segments from the source HDF5 product. The asset is `icesat2-atl06`, not `icesat2`.

PR #1075 mistakenly grouped `atl06sp` with `atl06p`. This corrects that:

- Remove `atl06sp` from `photonProcessingAPIs` so photon-processing params aren't sent in the request
- Show the read-only Extents display (`40m / 20m`, same as `atl06x`) for `atl06sp`
- Hide the Surface Elevation panel for `atl06sp` (fit was applied during ATL06 product generation)
- Add an `atl06sp` test case covering both `atl06_fields` and the correct `icesat2-atl06` asset
- Generalize comments / test descriptions from "X-series" to "subsetter endpoints" (which more accurately covers `atl06sp` + the X-series)

## Updated panel visibility by endpoint
| Endpoint | Photon Selection | Extents | Surface Elevation | PhoREAL |
|---|---|---|---|---|
| `atl03x` variants, `atl06p`, `atl08p`, `atl03vp` | editable | editable | if applicable | if applicable |
| `atl06sp` | hidden | **read-only: 40m / 20m** | hidden | n/a |
| `atl06x` | hidden | **read-only: 40m / 20m** | hidden | n/a |
| `atl08x` | hidden | **read-only: 100m / 100m** | n/a | hidden |
| `atl24x`, `atl13x` | hidden | hidden | n/a | n/a |

Refs #1074

## Test plan
- [x] `make lint` clean
- [x] `make test-unit` — 196 passing (added 2 new cases: `atl06sp` subsetter exclusion + `atl06sp` asset/fields test)
- [x] In Advanced mode, select `atl06sp` and verify: Photon Selection and Surface Elevation are hidden; Extents shows the read-only `40m / 20m` display; `atl06 Fields` editor still works under Ancillary Fields
- [x] Open the request Edit dialog for `atl06sp`; confirm JSON has `asset: "icesat2-atl06"`, no photon-processing params

🤖 Generated with [Claude Code](https://claude.com/claude-code)