### PR TITLE
Fix sidebar run button hidden after Home -> Request navigation

### DIFF
--- a/web-client/src/views/LandingView.vue
+++ b/web-client/src/views/LandingView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, watch, onMounted } from 'vue'
+import { ref, computed, watch, onMounted, onBeforeUnmount } from 'vue'
 import DOMPurify from 'dompurify'
 import { marked } from 'marked'
 import SelectButton from 'primevue/selectbutton'
@@ -212,6 +212,16 @@ onMounted(() => {
       })
     }
   }
+})
+
+// .sliderule-content is a persistent container owned by App.vue and shared
+// across every route. Restore it to the top before the next view mounts,
+// since we're the only view that scrolls it away from 0 (see Issue #1087).
+onBeforeUnmount(() => {
+  document.querySelector('.sliderule-content')?.scrollTo({
+    top: 0,
+    behavior: 'instant' as ScrollBehavior
+  })
 })
 
 watch(selectedTab, (tab) => {


### PR DESCRIPTION
## Summary
- `LandingView.vue`'s `onMounted` hook scrolls the shared `.sliderule-content` container (owned by `App.vue`, persistent across all route navigations) to center a panel/tab.
- Nothing ever reset that scroll position, so navigating Home -> Request left `RequestView`'s sidebar (and its run button) rendered below the fold, cropped by the leftover scroll offset.
- No other view touches `.sliderule-content`'s scroll, which is why this only reproduced from Home, as confirmed by the reporter.
- Fix: add an `onBeforeUnmount` hook in `LandingView.vue` that resets `.sliderule-content` back to the top before the next view mounts (Vue/vue-router guarantee the outgoing view's unmount hooks run before the incoming view mounts, so there's no race).

Fixes #1087

## Test plan
- [x] `make typecheck` passes
- [x] Reproduced the bug locally, verified navigating Home -> Request no longer hides the sidebar's run button
- [ ] Regression: Request reached from Settings/Server/RecTree/Globe still fine
- [ ] Regression: Home -> other views still fine